### PR TITLE
fix: Trace viewer precision

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "jest": "29.6.4",
     "prettier": "^3",
     "supertest": "6.3.3",
+    "ts-jest": "^29.1.1",
     "ts-node": "10.9.1",
     "turbo": "1.10.13",
     "typescript": "^5.2.0"

--- a/packages/time/jest.config.js
+++ b/packages/time/jest.config.js
@@ -1,0 +1,5 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+};

--- a/packages/time/package.json
+++ b/packages/time/package.json
@@ -14,6 +14,7 @@
   "homepage": "https://github.com/rocket-connect/graphql-debugger#readme",
   "scripts": {
     "build": "tsc",
+    "test": "jest",
     "start": "node build/index.js",
     "dev": "NODE_ENV=development ts-node ./src/index.ts"
   },

--- a/packages/time/src/timestamp.test.ts
+++ b/packages/time/src/timestamp.test.ts
@@ -1,0 +1,33 @@
+import { TimeStamp } from "./timestamp";
+
+describe("TimeStamp", () => {
+  describe("toStorage", () => {
+    it("should return the input", () => {
+      const now = new Date();
+
+      const ts = new TimeStamp(now);
+
+      expect(ts.toStorage()).toEqual(now);
+    });
+  });
+
+  describe("toString", () => {
+    it("should return a stringified version of the input", () => {
+      const now = new Date();
+
+      const ts = new TimeStamp(now);
+
+      expect(ts.toString()).toEqual(now.toString());
+    });
+  });
+
+  describe("moment", () => {
+    it("should return the input in moment format", () => {
+      const janfirst = new Date(2023, 0, 1);
+
+      const ts = new TimeStamp(janfirst);
+
+      expect(ts.moment.year()).toBe(2023);
+    });
+  });
+});

--- a/packages/time/src/unix-nano.test.ts
+++ b/packages/time/src/unix-nano.test.ts
@@ -202,4 +202,18 @@ describe("UnixNanoTimeStamp", () => {
       expect(ts.multiply(BigInt(2)).getBigInt()).toBe(BigInt(200));
     });
   });
+
+  describe("formatUnixNanoTimestamp", () => {
+    it("should format the UnixNanoTimeStamp as expected", () => {
+      const unixNanoTimeStamp = UnixNanoTimeStamp.fromString(
+        "1694213499416000000",
+      );
+
+      const formattedTimestamp = unixNanoTimeStamp.formatUnixNanoTimestamp();
+
+      const expectedFormat = "Sep 8, 2023 at 11:51:39 PM";
+
+      expect(formattedTimestamp).toContain(expectedFormat);
+    });
+  });
 });

--- a/packages/time/src/unix-nano.test.ts
+++ b/packages/time/src/unix-nano.test.ts
@@ -1,0 +1,205 @@
+import { UnixNanoTimeStamp } from "./unix-nano";
+
+describe("UnixNanoTimeStamp", () => {
+  describe("getBigInt", () => {
+    it("should return the input cast to a bigint", () => {
+      const ts = new UnixNanoTimeStamp(100);
+
+      const bi = ts.getBigInt();
+
+      expect(typeof bi).toEqual("bigint");
+      expect(bi).toEqual(BigInt(100));
+    });
+  });
+
+  describe("toStorage", () => {
+    it("should return the input cast to a bigint", () => {
+      const ts = new UnixNanoTimeStamp(100);
+
+      const bi = ts.toStorage();
+
+      expect(typeof bi).toEqual("bigint");
+      expect(bi).toEqual(BigInt(100));
+    });
+  });
+
+  describe("toString", () => {
+    it("should return the input as a string", () => {
+      const ts = new UnixNanoTimeStamp(100);
+
+      expect(ts.toString()).toEqual("100");
+    });
+  });
+
+  describe("fromString", () => {
+    it("should create a UnixNanoTimeStamp from a numeric string", () => {
+      const ts = UnixNanoTimeStamp.fromString("100");
+
+      expect(Number(ts.getBigInt())).toBe(100);
+    });
+  });
+
+  describe("toMS", () => {
+    it("should return the number of ms in the timestamp", () => {
+      const ts = new UnixNanoTimeStamp(1694342543499);
+
+      expect(ts.toMS()).toBe(1694342);
+    });
+  });
+
+  describe("toSIUnits", () => {
+    it.each([
+      { value: 1.23, unit: "s", input: "1230000000" },
+      { value: 123.456, unit: "ms", input: "123456000" },
+      { value: 123.456, unit: "μs", input: "123456" },
+      { value: 123, unit: "ns", input: "123" },
+    ])("should return $value $unit", ({ value, unit, input }) => {
+      const ts = UnixNanoTimeStamp.fromString(input);
+
+      expect(ts.toSIUnits()).toEqual({
+        value,
+        unit,
+      });
+    });
+  });
+
+  describe("calculateWidthAndOffset", () => {
+    const minTimestamp = UnixNanoTimeStamp.fromString("1694213499416000000");
+    const maxTimestamp = UnixNanoTimeStamp.fromString("1694213500062032384");
+
+    it.each([
+      {
+        duration: UnixNanoTimeStamp.fromString("347276288"),
+        startTimestamp: UnixNanoTimeStamp.fromString("1694213499416000000"),
+        width: "53%",
+        offset: "0%",
+      },
+      {
+        duration: UnixNanoTimeStamp.fromString("297915904"),
+        startTimestamp: UnixNanoTimeStamp.fromString("1694213499764000000"),
+        width: "46%",
+        offset: "53%",
+      },
+      {
+        duration: UnixNanoTimeStamp.fromString("32256"),
+        startTimestamp: UnixNanoTimeStamp.fromString("1694213500062000128"),
+        width: "5%",
+        offset: "99%",
+      },
+    ])(
+      "should return a $width width and $offset offset",
+      ({ duration, startTimestamp, width, offset }) => {
+        expect(
+          duration.calculateWidthAndOffset(
+            startTimestamp,
+            minTimestamp,
+            maxTimestamp,
+          ),
+        ).toEqual({ width, offset });
+      },
+    );
+  });
+
+  describe("toTimeStamp", () => {
+    it("should return a new TimeStamp", () => {
+      const unts = new UnixNanoTimeStamp(BigInt(1694368087997));
+
+      const ts = unts.toTimeStamp();
+
+      expect(ts.moment.year()).toBe(2023);
+    });
+  });
+
+  describe("duration", () => {
+    it("should return the duration between two timestamps", () => {
+      const from = new UnixNanoTimeStamp(300);
+      const to = new UnixNanoTimeStamp(550);
+
+      expect(UnixNanoTimeStamp.duration(from, to).getBigInt()).toBe(
+        BigInt(250),
+      );
+    });
+  });
+
+  describe("average", () => {
+    it("should average a list of UnixNanoTimeStamps", () => {
+      const time1 = new UnixNanoTimeStamp(10);
+      const time2 = new UnixNanoTimeStamp(20);
+      const time3 = new UnixNanoTimeStamp(30);
+
+      expect(UnixNanoTimeStamp.average([time1, time2, time3]).getBigInt()).toBe(
+        BigInt(20),
+      );
+    });
+
+    it("should return 1 if the list is empty", () => {
+      expect(UnixNanoTimeStamp.average([]).getBigInt()).toBe(BigInt(1));
+    });
+
+    it("should set the numerator to 1 if the total timestamps are 0", () => {
+      const time1 = new UnixNanoTimeStamp(0);
+      const time2 = new UnixNanoTimeStamp(0);
+      const time3 = new UnixNanoTimeStamp(0);
+
+      expect(UnixNanoTimeStamp.average([time1, time2, time3]).getBigInt()).toBe(
+        BigInt(0),
+      );
+    });
+  });
+
+  describe("earliest", () => {
+    it("should find the earliest timestamp in an array", () => {
+      const time1 = new UnixNanoTimeStamp(20);
+      const time2 = new UnixNanoTimeStamp(10);
+      const time3 = new UnixNanoTimeStamp(30);
+
+      expect(
+        UnixNanoTimeStamp.earliest([time1, time2, time3]).getBigInt(),
+      ).toBe(BigInt(10));
+    });
+  });
+
+  describe("latest", () => {
+    it("should find the latest timestamp in an array", () => {
+      const time1 = new UnixNanoTimeStamp(20);
+      const time2 = new UnixNanoTimeStamp(10);
+      const time3 = new UnixNanoTimeStamp(30);
+
+      expect(UnixNanoTimeStamp.latest([time1, time2, time3]).getBigInt()).toBe(
+        BigInt(30),
+      );
+    });
+  });
+
+  describe("subtract", () => {
+    it("should subtract one timestamp from another", () => {
+      const ts = new UnixNanoTimeStamp(100);
+      const anotherTs = new UnixNanoTimeStamp(30);
+
+      expect(ts.subtract(anotherTs).getBigInt()).toBe(BigInt(70));
+    });
+
+    it("should subtract one bigint from a timestamp", () => {
+      const ts = new UnixNanoTimeStamp(100);
+      const another = BigInt(30);
+
+      expect(ts.subtract(another).getBigInt()).toBe(BigInt(70));
+    });
+  });
+
+  describe("divide", () => {
+    it("should divide a timestamp by a bigint", () => {
+      const ts = new UnixNanoTimeStamp(100);
+
+      expect(ts.divide(BigInt(2)).getBigInt()).toBe(BigInt(50));
+    });
+  });
+
+  describe("multiply", () => {
+    it("should multiply a timestamp by a bigint", () => {
+      const ts = new UnixNanoTimeStamp(100);
+
+      expect(ts.multiply(BigInt(2)).getBigInt()).toBe(BigInt(200));
+    });
+  });
+});

--- a/packages/time/src/unix-nano.test.ts
+++ b/packages/time/src/unix-nano.test.ts
@@ -209,7 +209,9 @@ describe("UnixNanoTimeStamp", () => {
         "1694213499416000000",
       );
 
-      const formattedTimestamp = unixNanoTimeStamp.formatUnixNanoTimestamp();
+      const formattedTimestamp = unixNanoTimeStamp.formatUnixNanoTimestamp({
+        timeZone: "utc",
+      });
 
       const expectedFormat = "Sep 8, 2023 at 10:51:39 PM UTC";
 

--- a/packages/time/src/unix-nano.test.ts
+++ b/packages/time/src/unix-nano.test.ts
@@ -211,7 +211,7 @@ describe("UnixNanoTimeStamp", () => {
 
       const formattedTimestamp = unixNanoTimeStamp.formatUnixNanoTimestamp();
 
-      const expectedFormat = "Sep 8, 2023 at 11:51:39 PM";
+      const expectedFormat = "Sep 8, 2023 at 10:51:39 PM UTC";
 
       expect(formattedTimestamp).toContain(expectedFormat);
     });

--- a/packages/time/src/unix-nano.ts
+++ b/packages/time/src/unix-nano.ts
@@ -78,7 +78,6 @@ export class UnixNanoTimeStamp {
     width: string;
     offset: string;
   } {
-
     const timespan = UnixNanoTimeStamp.duration(
       minTimestamp,
       maxTimestamp,
@@ -100,7 +99,9 @@ export class UnixNanoTimeStamp {
   }
 
   public toTimeStamp(): TimeStamp {
-    return new TimeStamp(new Date(Number(this.input)));
+    const date = new Date(Number(this.input) / Number(ms));
+
+    return new TimeStamp(date);
   }
 
   public static duration(

--- a/packages/time/src/unix-nano.ts
+++ b/packages/time/src/unix-nano.ts
@@ -78,12 +78,6 @@ export class UnixNanoTimeStamp {
     width: string;
     offset: string;
   } {
-    console.log({
-      duration: this.getBigInt(),
-      startTimestamp,
-      minTimestamp,
-      maxTimestamp,
-    });
 
     const timespan = UnixNanoTimeStamp.duration(
       minTimestamp,

--- a/packages/time/src/unix-nano.ts
+++ b/packages/time/src/unix-nano.ts
@@ -99,9 +99,29 @@ export class UnixNanoTimeStamp {
   }
 
   public toTimeStamp(): TimeStamp {
-    const date = new Date(Number(this.input) / Number(ms));
+    const date = new Date(Number(this.input));
 
     return new TimeStamp(date);
+  }
+
+  public formatUnixNanoTimestamp() {
+    const milliseconds = Number(this.getBigInt()) / 1e6;
+    const date = new Date(milliseconds);
+
+    const formattedDate = date.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+
+    const formattedTime = date.toLocaleTimeString("en-US", {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      timeZoneName: "short",
+    });
+
+    return `${formattedDate} at ${formattedTime}`;
   }
 
   public static duration(

--- a/packages/time/src/unix-nano.ts
+++ b/packages/time/src/unix-nano.ts
@@ -1,5 +1,17 @@
 import { TimeStamp } from "./timestamp";
 
+/** BigInt representation of a second */
+const s = BigInt(1_000_000_000);
+/** BigInt representation of a millisecond */
+const ms = BigInt(1_000_000);
+/** BigInt representation of a microsecond */
+const us = BigInt(1_000);
+
+/** Helper constant for calculating percentages without losing resolution */
+const percentageMultiplyer = BigInt(100);
+/** Helper constant representing the number 1 */
+const bigintOne = BigInt(1);
+
 export class UnixNanoTimeStamp {
   private input: number | bigint;
 
@@ -24,39 +36,77 @@ export class UnixNanoTimeStamp {
   }
 
   public toMS(): number {
-    const ms = Number(BigInt(this.getBigInt()) / BigInt(1000000));
+    const _ms = Number(this.getBigInt() / ms);
 
-    return ms;
+    return _ms;
+  }
+
+  public toSIUnits(): {
+    value: number;
+    unit: "s" | "ms" | "μs" | "ns";
+  } {
+    const bigintInput = this.getBigInt();
+
+    if (bigintInput >= s) {
+      return {
+        value: Number(this.multiply(s).divide(s).getBigInt()) / Number(s),
+        unit: "s",
+      };
+    } else if (bigintInput >= ms) {
+      return {
+        value: Number(this.multiply(ms).divide(ms).getBigInt()) / Number(ms),
+        unit: "ms",
+      };
+    } else if (bigintInput >= us) {
+      return {
+        value: Number(this.multiply(us).divide(us).getBigInt()) / Number(us),
+        unit: "μs",
+      };
+    } else {
+      return {
+        value: Number(bigintInput),
+        unit: "ns",
+      };
+    }
   }
 
   public calculateWidthAndOffset(
+    startTimestamp: UnixNanoTimeStamp,
     minTimestamp: UnixNanoTimeStamp,
     maxTimestamp: UnixNanoTimeStamp,
   ): {
     width: string;
     offset: string;
   } {
-    const diffMs = Number(
-      maxTimestamp.subtract(minTimestamp).divide(BigInt(1000000)),
-    );
+    console.log({
+      duration: this.getBigInt(),
+      startTimestamp,
+      minTimestamp,
+      maxTimestamp,
+    });
 
-    const startTimeMs = Number(
-      this.subtract(minTimestamp).divide(BigInt(1000000)),
-    );
+    const timespan = UnixNanoTimeStamp.duration(
+      minTimestamp,
+      maxTimestamp,
+    ).getBigInt();
 
-    const calculatedWidth = (startTimeMs / diffMs) * 100;
+    const calculatedWidth = this.multiply(percentageMultiplyer)
+      .divide(timespan)
+      .getBigInt();
     const width = calculatedWidth < 5 ? "5%" : `${calculatedWidth}%`;
 
-    const calculatedOffset = (startTimeMs / diffMs) * 100;
+    const calculatedOffset = startTimestamp
+      .subtract(minTimestamp)
+      .multiply(percentageMultiplyer)
+      .divide(timespan)
+      .getBigInt();
     const offset = calculatedOffset < 0 ? "0%" : `${calculatedOffset}%`;
 
     return { width, offset };
   }
 
   public toTimeStamp(): TimeStamp {
-    const ms = this.toMS();
-
-    return new TimeStamp(new Date(ms));
+    return new TimeStamp(new Date(Number(this.input)));
   }
 
   public static duration(
@@ -70,33 +120,20 @@ export class UnixNanoTimeStamp {
 
   public static average(times: UnixNanoTimeStamp[]): UnixNanoTimeStamp {
     const sum = times.reduce((a, b) => a + b.getBigInt(), BigInt(0));
-    const lengthBigInt = BigInt(times.length);
-    const bigintOne = BigInt(1);
+    const length = BigInt(times.length);
+
     const average =
-      (sum > 0 ? sum : bigintOne) /
-      (lengthBigInt > 0 ? lengthBigInt : bigintOne);
+      (sum > 0 ? sum : bigintOne) / (length > 0 ? length : bigintOne);
 
     return new UnixNanoTimeStamp(average);
   }
 
   public static earliest(times: UnixNanoTimeStamp[]): UnixNanoTimeStamp {
-    let minTimestamp = times[0];
-    for (const timestamp of times) {
-      if (timestamp.getBigInt() < minTimestamp.getBigInt()) {
-        minTimestamp = timestamp;
-      }
-    }
-    return minTimestamp;
+    return times.reduce((min, c) => (c.input < min.input ? c : min));
   }
 
   public static latest(times: UnixNanoTimeStamp[]): UnixNanoTimeStamp {
-    let maxTimestamp = times[0];
-    for (const timestamp of times) {
-      if (timestamp.getBigInt() > maxTimestamp.getBigInt()) {
-        maxTimestamp = timestamp;
-      }
-    }
-    return maxTimestamp;
+    return times.reduce((max, c) => (c.input > max.input ? c : max));
   }
 
   public subtract(another: UnixNanoTimeStamp | bigint): UnixNanoTimeStamp {
@@ -108,6 +145,11 @@ export class UnixNanoTimeStamp {
 
   public divide(divisor: bigint): UnixNanoTimeStamp {
     const result = this.getBigInt() / divisor;
+    return new UnixNanoTimeStamp(result);
+  }
+
+  public multiply(multiplier: bigint): UnixNanoTimeStamp {
+    const result = this.getBigInt() * multiplier;
     return new UnixNanoTimeStamp(result);
   }
 }

--- a/packages/time/src/unix-nano.ts
+++ b/packages/time/src/unix-nano.ts
@@ -104,7 +104,7 @@ export class UnixNanoTimeStamp {
     return new TimeStamp(date);
   }
 
-  public formatUnixNanoTimestamp() {
+  public formatUnixNanoTimestamp({ timeZone }: { timeZone?: "utc" } = {}) {
     const milliseconds = Number(this.getBigInt()) / 1e6;
     const date = new Date(milliseconds);
 
@@ -112,7 +112,7 @@ export class UnixNanoTimeStamp {
       year: "numeric",
       month: "short",
       day: "numeric",
-      timeZone: "UTC",
+      timeZone,
     });
 
     const formattedTime = date.toLocaleTimeString("en-US", {
@@ -120,7 +120,7 @@ export class UnixNanoTimeStamp {
       minute: "2-digit",
       second: "2-digit",
       timeZoneName: "short",
-      timeZone: "UTC",
+      timeZone,
     });
 
     return `${formattedDate} at ${formattedTime}`;

--- a/packages/time/src/unix-nano.ts
+++ b/packages/time/src/unix-nano.ts
@@ -112,6 +112,7 @@ export class UnixNanoTimeStamp {
       year: "numeric",
       month: "short",
       day: "numeric",
+      timeZone: "UTC",
     });
 
     const formattedTime = date.toLocaleTimeString("en-US", {
@@ -119,6 +120,7 @@ export class UnixNanoTimeStamp {
       minute: "2-digit",
       second: "2-digit",
       timeZoneName: "short",
+      timeZone: "UTC",
     });
 
     return `${formattedDate} at ${formattedTime}`;

--- a/packages/ui/src/components/SchemaTraces.tsx
+++ b/packages/ui/src/components/SchemaTraces.tsx
@@ -112,7 +112,7 @@ export function SchemaTraces({ schemaId }: { schemaId: string }) {
                   {durationUnixNano.toMS().toFixed(2)} ms
                 </td>
                 <td className="px-6 py-4">
-                  {startTimeUnixNano.toTimeStamp().moment.fromNow()}
+                  {startTimeUnixNano.formatUnixNanoTimestamp()}
                 </td>
               </tr>
             );

--- a/packages/ui/src/components/schema-viewer/Stats.tsx
+++ b/packages/ui/src/components/schema-viewer/Stats.tsx
@@ -13,6 +13,8 @@ export function Stats({
     aggregate?.averageDuration || "0",
   );
 
+  const hasResolved = lastResolveUnixNano.toString() !== "0";
+
   return (
     <div className="pl-2 text-xs font-light text-graphiql-light">
       <ul className="list-disc list-inside marker:text-graphql-otel-green flex flex-col gap-2 ">
@@ -30,12 +32,16 @@ export function Stats({
           Average Duration:{" "}
           <span className="font-bold">{averageDurationUnixNano.toMS()} ms</span>
         </li>
-        <li>
-          Last Resolved:{" "}
-          <span className="font-bold">
-            {lastResolveUnixNano.toTimeStamp().moment.fromNow()}
-          </span>
-        </li>
+        {hasResolved ? (
+          <li>
+            Last Resolved:{" "}
+            <span className="font-bold">
+              {lastResolveUnixNano.toTimeStamp().moment.fromNow()}
+            </span>
+          </li>
+        ) : (
+          <></>
+        )}
       </ul>
     </div>
   );

--- a/packages/ui/src/components/schema-viewer/Stats.tsx
+++ b/packages/ui/src/components/schema-viewer/Stats.tsx
@@ -36,7 +36,7 @@ export function Stats({
           <li>
             Last Resolved:{" "}
             <span className="font-bold">
-              {lastResolveUnixNano.toTimeStamp().moment.fromNow()}
+              {lastResolveUnixNano.formatUnixNanoTimestamp()}
             </span>
           </li>
         ) : (

--- a/packages/ui/src/components/trace-viewer/Span.tsx
+++ b/packages/ui/src/components/trace-viewer/Span.tsx
@@ -1,4 +1,5 @@
-import { RenderTree, ms } from "./utils";
+import { UnixNanoTimeStamp } from "@graphql-debugger/time";
+import { RenderTree } from "./utils";
 
 export function Span({
   data,
@@ -6,19 +7,21 @@ export function Span({
   maxTimestamp,
 }: {
   data: RenderTree;
-  minTimestamp: number;
-  maxTimestamp: number;
+  minTimestamp: UnixNanoTimeStamp;
+  maxTimestamp: UnixNanoTimeStamp;
 }) {
-  const calculatedWidth =
-    (Number(BigInt(data.durationNano) / ms) / (maxTimestamp - minTimestamp)) *
-    100;
-  const width = calculatedWidth < 5 ? "5%" : `${calculatedWidth}%`;
+  const durationNano = UnixNanoTimeStamp.fromString(data.durationNano);
+  const startTimeUnixNano = UnixNanoTimeStamp.fromString(
+    data.startTimeUnixNano,
+  );
 
-  const calculatedOffset =
-    ((Number(BigInt(data.startTimeUnixNano) / ms) - minTimestamp) /
-      (maxTimestamp - minTimestamp)) *
-    100;
-  const offset = calculatedOffset < 0 ? "0%" : `${calculatedOffset}%`;
+  const { width, offset } = durationNano.calculateWidthAndOffset(
+    startTimeUnixNano,
+    minTimestamp,
+    maxTimestamp,
+  );
+
+  const { value, unit } = durationNano.toSIUnits();
 
   let spanClasses = "absolute h-2";
   if (data.errorMessage) {
@@ -40,10 +43,7 @@ export function Span({
         >
           {data.name}{" "}
           <span className="font-light">
-            {Number(BigInt(data?.durationNano || 0) / BigInt(1000000)).toFixed(
-              2,
-            )}{" "}
-            ms
+            {Number(value).toFixed(2)} {unit}
           </span>
         </p>
         <div className={`absolute h-2 bg-graphiql-border w-full`}></div>

--- a/packages/ui/src/components/trace-viewer/TraceViewer.tsx
+++ b/packages/ui/src/components/trace-viewer/TraceViewer.tsx
@@ -2,17 +2,19 @@ import { useEffect, useState } from "react";
 import { listTraceGroups } from "../../api/list-trace-groups";
 import { useParams } from "react-router-dom";
 import { Span } from "./Span";
-import { createTreeData, ms } from "./utils";
+import { createTreeData } from "./utils";
 import { Span as TSpan, Trace } from "../../graphql-types";
 import { IDS } from "../../testing";
+import { UnixNanoTimeStamp } from "@graphql-debugger/time";
 
 const TraceView = ({ spans }: { spans: TSpan[] }) => {
   const treeData = createTreeData(spans);
-  const minTimestamp = Math.min(
-    ...spans.map((t) => Number(BigInt(t.startTimeUnixNano) / ms)),
+
+  const minTimestamp = UnixNanoTimeStamp.earliest(
+    spans.map((t) => UnixNanoTimeStamp.fromString(t.startTimeUnixNano)),
   );
-  const maxTimestamp = Math.max(
-    ...spans.map((t) => Number(BigInt(t.endTimeUnixNano) / ms)),
+  const maxTimestamp = UnixNanoTimeStamp.latest(
+    spans.map((t) => UnixNanoTimeStamp.fromString(t.endTimeUnixNano)),
   );
 
   return (

--- a/packages/ui/src/components/trace-viewer/utils.ts
+++ b/packages/ui/src/components/trace-viewer/utils.ts
@@ -4,8 +4,6 @@ export type RenderTree = Omit<Span, "__typename"> & {
   children: RenderTree[];
 };
 
-export const ms = BigInt(1000000);
-
 export const createTreeData = (spanArray: Span[]): RenderTree[] => {
   const treeData: RenderTree[] = [];
   const lookup: { [key: string]: RenderTree } = {};

--- a/packages/ui/src/pages/Schema.tsx
+++ b/packages/ui/src/pages/Schema.tsx
@@ -123,7 +123,7 @@ export function Schema() {
                     </p>
                   </div>
                   <p className="py-1 text-xs text-graphiql-dark italic">
-                    {startTimeUnixNano.toTimeStamp().moment.fromNow()}
+                    {startTimeUnixNano.formatUnixNanoTimestamp()}
                   </p>
                 </div>
               )}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       supertest:
         specifier: 6.3.3
         version: 6.3.3
+      ts-jest:
+        specifier: ^29.1.1
+        version: 29.1.1(@babel/core@7.22.17)(jest@29.6.4)(typescript@5.2.2)
       ts-node:
         specifier: 10.9.1
         version: 10.9.1(@types/node@18.17.14)(typescript@5.2.2)
@@ -4828,6 +4831,13 @@ packages:
       update-browserslist-db: 1.0.11(browserslist@4.21.10)
     dev: true
 
+  /bs-logger@0.2.6:
+    resolution: {integrity: sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==}
+    engines: {node: '>= 6'}
+    dependencies:
+      fast-json-stable-stringify: 2.1.0
+    dev: true
+
   /bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
     dependencies:
@@ -8260,6 +8270,10 @@ packages:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
     dev: true
 
+  /lodash.memoize@4.1.2:
+    resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
+    dev: true
+
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
@@ -10469,6 +10483,44 @@ packages:
 
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+    dev: true
+
+  /ts-jest@29.1.1(@babel/core@7.22.17)(jest@29.6.4)(typescript@5.2.2):
+    resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@jest/types': ^29.0.0
+      babel-jest: ^29.0.0
+      esbuild: '*'
+      jest: ^29.0.0
+      typescript: '>=4.3 <6'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@jest/types':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+      jest:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@babel/core': 7.22.17
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.6.4(@types/node@18.17.14)(ts-node@10.9.1)
+      jest-util: 29.6.3
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.5.4
+      typescript: 5.2.2
+      yargs-parser: 21.1.1
     dev: true
 
   /ts-loader@9.4.4(typescript@5.2.2)(webpack@5.88.2):


### PR DESCRIPTION
Closes #7

Bolsters the logic within `unix-nano` and utilises it within the `Span` and `TraceViewer` components.

We can probably make the precision even better with some proper BigInt maths, as division causes massive drops in resolution that I'm working around thanks to [this Stackoverflow post](https://stackoverflow.com/questions/54409854/how-to-divide-two-native-javascript-bigints-and-get-a-decimal-result), and there may be better maths libraries to work with. For now, I think this is good enough and shows the user trace widths for even tiny durations