### PR TITLE
feat: Display precise start and end times

### DIFF
--- a/packages/time/jest.config.js
+++ b/packages/time/jest.config.js
@@ -2,4 +2,5 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
+  testMatch: ["**/*.test.ts"],
 };

--- a/packages/time/src/unix-nano.test.ts
+++ b/packages/time/src/unix-nano.test.ts
@@ -213,7 +213,7 @@ describe("UnixNanoTimeStamp", () => {
         timeZone: "utc",
       });
 
-      const expectedFormat = "Sep 8, 2023 at 10:51:39 PM UTC";
+      const expectedFormat = "Sep 8, 2023 at 10:51:39.416 PM UTC";
 
       expect(formattedTimestamp).toContain(expectedFormat);
     });

--- a/packages/time/src/unix-nano.ts
+++ b/packages/time/src/unix-nano.ts
@@ -119,6 +119,7 @@ export class UnixNanoTimeStamp {
       hour: "2-digit",
       minute: "2-digit",
       second: "2-digit",
+      fractionalSecondDigits: 3,
       timeZoneName: "short",
       timeZone,
     });

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -16,8 +16,9 @@
     "build": "tsc",
     "test": "echo \"No tests\""
   },
-  "peerDependencies": {},
-  "dependencies": {},
+  "peerDependencies": {
+    "graphql": "^16.0.0 || ^17.0.0"
+  },
   "devDependencies": {
     "@graphql-debugger/schemas": "workspace:^"
   }

--- a/packages/ui/src/components/SchemaTraces.tsx
+++ b/packages/ui/src/components/SchemaTraces.tsx
@@ -57,9 +57,10 @@ export function SchemaTraces({ schemaId }: { schemaId: string }) {
     <div className="relative" id={IDS.SCHEMA_TRACES}>
       <table className="text-xs text-left w-full table-fixed">
         <colgroup>
-          <col className="w-1/3" />
-          <col className="w-1/3" />
-          <col className="w-1/3" />
+          <col className="w-1/4" />
+          <col className="w-1/4" />
+          <col className="w-1/4" />
+          <col className="w-1/4" />
         </colgroup>
         <thead className="text-xs text-graphiql-light">
           <tr>
@@ -70,7 +71,10 @@ export function SchemaTraces({ schemaId }: { schemaId: string }) {
               Duration
             </th>
             <th scope="col" className="px-6 py-3">
-              When
+              Start
+            </th>
+            <th scope="col" className="px-6 py-3">
+              End
             </th>
           </tr>
         </thead>
@@ -82,9 +86,14 @@ export function SchemaTraces({ schemaId }: { schemaId: string }) {
             const startTimeUnixNano = UnixNanoTimeStamp.fromString(
               rootSpan?.startTimeUnixNano || "0",
             );
+            const endTimeUnixNano = UnixNanoTimeStamp.fromString(
+              rootSpan?.endTimeUnixNano || "0",
+            );
             const durationUnixNano = UnixNanoTimeStamp.fromString(
               rootSpan?.durationNano || "0",
             );
+
+            const { value, unit } = durationUnixNano.toSIUnits();
 
             let traceClasses = "absolute h-3 ";
             if (isSelected) {
@@ -110,11 +119,12 @@ export function SchemaTraces({ schemaId }: { schemaId: string }) {
                 >
                   {rootSpan?.name}
                 </th>
-                <td className="px-6 py-4">
-                  {durationUnixNano.toMS().toFixed(2)} ms
-                </td>
+                <td className="px-6 py-4">{`${value.toFixed(2)} ${unit}`}</td>
                 <td className="px-6 py-4">
                   {startTimeUnixNano.formatUnixNanoTimestamp()}
+                </td>
+                <td className="px-6 py-4">
+                  {endTimeUnixNano.formatUnixNanoTimestamp()}
                 </td>
               </tr>
             );

--- a/packages/ui/src/pages/Schema.tsx
+++ b/packages/ui/src/pages/Schema.tsx
@@ -38,6 +38,8 @@ export function Schema() {
     trace?.rootSpan?.durationNano || "0",
   );
 
+  const traceDurationSIUnits = traceDurationUnixNano.toSIUnits();
+
   useEffect(() => {
     (async () => {
       try {
@@ -121,7 +123,9 @@ export function Schema() {
                     <p>{trace?.rootSpan?.name}</p>
                     <p>-</p>
                     <p className="text-xs my-auto">
-                      {traceDurationUnixNano.toMS().toFixed(2)} ms
+                      {`${traceDurationSIUnits.value.toFixed(2)} ${
+                        traceDurationSIUnits.unit
+                      }`}
                     </p>
                   </div>
                   <p className="py-1 text-xs text-graphiql-dark italic">

--- a/packages/ui/src/pages/Schema.tsx
+++ b/packages/ui/src/pages/Schema.tsx
@@ -34,6 +34,9 @@ export function Schema() {
   const startTimeUnixNano = UnixNanoTimeStamp.fromString(
     trace?.rootSpan?.startTimeUnixNano || "0",
   );
+  const endTimeUnixNano = UnixNanoTimeStamp.fromString(
+    trace?.rootSpan?.endTimeUnixNano || "0",
+  );
   const traceDurationUnixNano = UnixNanoTimeStamp.fromString(
     trace?.rootSpan?.durationNano || "0",
   );
@@ -264,6 +267,18 @@ export function Schema() {
                 <p className="text-graphiql-light text-xs py-3">
                   Breakdown of resolver execution time during the query.
                 </p>
+
+                <div className="flex flex-row justify-between gap-5 w-full text-graphiql-light">
+                  <p className="py-1 text-xs italic">
+                    {startTimeUnixNano.formatUnixNanoTimestamp()}
+                  </p>
+                  <div className="flex items-center w-full">
+                    <hr className="w-full" />
+                  </div>
+                  <p className="py-1 text-xs italic">
+                    {endTimeUnixNano.formatUnixNanoTimestamp()}
+                  </p>
+                </div>
 
                 <div className="overflow-scroll h-5/6">
                   {trace && <TraceViewer />}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -390,6 +390,10 @@ importers:
         version: 2.6.4
 
   packages/types:
+    dependencies:
+      graphql:
+        specifier: ^16.0.0 || ^17.0.0
+        version: 16.8.0
     devDependencies:
       '@graphql-debugger/schemas':
         specifier: workspace:^
@@ -6974,6 +6978,11 @@ packages:
   /graphql@16.0.0:
     resolution: {integrity: sha512-n9NxoRfwnpYBZB/WJ7L166gyrShuZ8qYgVaX8oxVyELcJfAwkvwPt6WlYIl90WRlzqDjaNWvLmNOSnKs5llZWQ==}
     engines: {node: ^12.22.0 || ^14.16.0 || >=16.0.0}
+
+  /graphql@16.8.0:
+    resolution: {integrity: sha512-0oKGaR+y3qcS5mCu1vb7KG+a89vjn06C7Ihq/dDl3jA+A8B3TKomvi3CiEcVLJQGalbu8F52LxkOym7U5sSfbg==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+    dev: false
 
   /handle-thing@2.0.1:
     resolution: {integrity: sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==}


### PR DESCRIPTION
Closes #6 

- Adds precise timings for all displays in the Trace Viewer
- Adds Start and End columns
- Adds Start and End times above the Spans