### PR TITLE
chore: TypeScript project references

### DIFF
--- a/.github/actions/setup-project/action.yml
+++ b/.github/actions/setup-project/action.yml
@@ -7,9 +7,6 @@ inputs:
   node-version:
     required: false
     default: 18
-  turbo-version:
-    required: false
-    default: 1.10.7
 
 runs:
   using: composite
@@ -21,9 +18,6 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
         cache: "pnpm"
-    - name: Install Turbo
-      run: npm i -g turbo@${{ inputs.turbo-version }}
-      shell: bash
     - name: Install dependencies
       run: pnpm install
       shell: bash

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -20,7 +20,6 @@
     "@graphql-debugger/collector-proxy": "workspace:^",
     "@graphql-debugger/graphql-schema": "workspace:^",
     "@graphql-debugger/data-access": "workspace:^",
-    "@graphql-debugger/utils": "workspace:^",
     "@graphql-debugger/ui": "workspace:^",
     "cors": "2.8.5",
     "express": "4.18.2",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -13,7 +13,7 @@
   },
   "homepage": "https://github.com/rocket-connect/graphql-debugger#readme",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "test": "echo \"No tests\""
   },
   "dependencies": {

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -2,12 +2,13 @@
   "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "target": "ES2020",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true,
     "outDir": "build",
     "declarationMap": true,
-    "declaration": true
-  }
+    "declaration": true,
+    "baseUrl": ".",
+    "paths": {
+      "@graphql-debugger/utils": ["../utils"]
+    }
+  },
+  "references": [{ "path": "../utils" }]
 }

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -7,8 +7,8 @@
     "declaration": true,
     "baseUrl": ".",
     "paths": {
-      "@graphql-debugger/utils": ["../utils"]
+      "@graphql-debugger/utils": ["../../packages/utils"]
     }
   },
-  "references": [{ "path": "../utils" }]
+  "references": [{ "path": "../../packages/utils" }]
 }

--- a/apps/collector-proxy/jest.config.js
+++ b/apps/collector-proxy/jest.config.js
@@ -10,7 +10,7 @@ module.exports = {
   ],
   setupFilesAfterEnv: ["<rootDir>/tests/setup.ts"],
   transform: {
-    "\\.ts$": ["ts-jest", { tsconfig: "tsconfig.test.json" }],
+    "\\.ts$": ["ts-jest"],
   },
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
     prefix: __dirname,

--- a/apps/collector-proxy/jest.config.js
+++ b/apps/collector-proxy/jest.config.js
@@ -1,14 +1,18 @@
+const { compilerOptions } = require("./tsconfig.json");
+const { pathsToModuleNameMapper } = require("ts-jest");
+
+/** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   modulePathIgnorePatterns: [
     "<rootDir>/build/",
     "<rootDir>/node_modules/",
     "<rootDir>/build/",
   ],
-  testTimeout: 150000,
   setupFilesAfterEnv: ["<rootDir>/tests/setup.ts"],
-  globals: {
-    "ts-jest": {
-      tsconfig: "tsconfig.test.json",
-    },
+  transform: {
+    "\\.ts$": ["ts-jest", { tsconfig: "tsconfig.test.json" }],
   },
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
+    prefix: __dirname,
+  }),
 };

--- a/apps/collector-proxy/package.json
+++ b/apps/collector-proxy/package.json
@@ -23,7 +23,6 @@
     "@graphql-debugger/data-access": "workspace:^",
     "@graphql-debugger/trace-schema": "workspace:^",
     "@graphql-debugger/queue": "workspace:^",
-    "@graphql-debugger/schemas": "workspace:^",
     "@graphql-debugger/opentelemetry": "workspace:^",
     "@graphql-tools/schema": "10.0.0",
     "@graphql-tools/utils": "10.0.6",

--- a/apps/collector-proxy/package.json
+++ b/apps/collector-proxy/package.json
@@ -20,7 +20,6 @@
     "graphql": "^16.0.0 || ^17.0.0"
   },
   "dependencies": {
-    "@graphql-debugger/time": "workspace:^",
     "@graphql-debugger/utils": "workspace:^",
     "@graphql-debugger/data-access": "workspace:^",
     "@graphql-debugger/trace-schema": "workspace:^",

--- a/apps/collector-proxy/package.json
+++ b/apps/collector-proxy/package.json
@@ -29,7 +29,6 @@
     "express": "4.18.2"
   },
   "devDependencies": {
-    "@graphql-debugger/types": "workspace:^",
     "@faker-js/faker": "8.0.2"
   }
 }

--- a/apps/collector-proxy/package.json
+++ b/apps/collector-proxy/package.json
@@ -13,7 +13,7 @@
   },
   "homepage": "https://github.com/rocket-connect/graphql-debugger#readme",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc -b tsconfig.build.json",
     "test": "cross-env NODE_ENV=test jest --runInBand"
   },
   "peerDependencies": {

--- a/apps/collector-proxy/package.json
+++ b/apps/collector-proxy/package.json
@@ -20,7 +20,6 @@
     "graphql": "^16.0.0 || ^17.0.0"
   },
   "dependencies": {
-    "@graphql-debugger/utils": "workspace:^",
     "@graphql-debugger/data-access": "workspace:^",
     "@graphql-debugger/trace-schema": "workspace:^",
     "@graphql-debugger/queue": "workspace:^",

--- a/apps/collector-proxy/package.json
+++ b/apps/collector-proxy/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@graphql-debugger/data-access": "workspace:^",
     "@graphql-debugger/trace-schema": "workspace:^",
-    "@graphql-debugger/opentelemetry": "workspace:^",
     "@graphql-tools/schema": "10.0.0",
     "@graphql-tools/utils": "10.0.6",
     "express": "4.18.2"

--- a/apps/collector-proxy/package.json
+++ b/apps/collector-proxy/package.json
@@ -13,7 +13,7 @@
   },
   "homepage": "https://github.com/rocket-connect/graphql-debugger#readme",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --project tsconfig.build.json",
     "test": "cross-env NODE_ENV=test jest --runInBand"
   },
   "peerDependencies": {
@@ -22,7 +22,6 @@
   "dependencies": {
     "@graphql-debugger/data-access": "workspace:^",
     "@graphql-debugger/trace-schema": "workspace:^",
-    "@graphql-debugger/queue": "workspace:^",
     "@graphql-debugger/opentelemetry": "workspace:^",
     "@graphql-tools/schema": "10.0.0",
     "@graphql-tools/utils": "10.0.6",

--- a/apps/collector-proxy/tsconfig.build.json
+++ b/apps/collector-proxy/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["tests/"],
+  "include": ["src/**/*"]
+}

--- a/apps/collector-proxy/tsconfig.json
+++ b/apps/collector-proxy/tsconfig.json
@@ -8,11 +8,16 @@
     "rootDir": "./src/",
     "baseUrl": ".",
     "paths": {
+      "@graphql-debugger/schemas": ["../schemas"],
       "@graphql-debugger/time": ["../time"],
       "@graphql-debugger/utils": ["../utils"]
     }
   },
-  "references": [{ "path": "../time" }, { "path": "../utils" }],
+  "references": [
+    { "path": "../schemas" },
+    { "path": "../time" },
+    { "path": "../utils" }
+  ],
   "exclude": ["tests/"],
   "include": ["src/**/*"]
 }

--- a/apps/collector-proxy/tsconfig.json
+++ b/apps/collector-proxy/tsconfig.json
@@ -8,10 +8,11 @@
     "rootDir": "./src/",
     "baseUrl": ".",
     "paths": {
-      "@graphql-debugger/time": ["../time"]
+      "@graphql-debugger/time": ["../time"],
+      "@graphql-debugger/utils": ["../utils"]
     }
   },
-  "references": [{ "path": "../time" }],
+  "references": [{ "path": "../time" }, { "path": "../utils" }],
   "exclude": ["tests/"],
   "include": ["src/**/*"]
 }

--- a/apps/collector-proxy/tsconfig.json
+++ b/apps/collector-proxy/tsconfig.json
@@ -7,20 +7,20 @@
     "declaration": true,
     "baseUrl": ".",
     "paths": {
-      "@graphql-debugger/opentelemetry": ["../opentelemetry"],
-      "@graphql-debugger/queue": ["../queue"],
-      "@graphql-debugger/schemas": ["../schemas"],
-      "@graphql-debugger/time": ["../time"],
-      "@graphql-debugger/types": ["../types"],
-      "@graphql-debugger/utils": ["../utils"]
+      "@graphql-debugger/opentelemetry": ["../../packages/opentelemetry"],
+      "@graphql-debugger/queue": ["../../packages/queue"],
+      "@graphql-debugger/schemas": ["../../packages/schemas"],
+      "@graphql-debugger/time": ["../../packages/time"],
+      "@graphql-debugger/types": ["../../packages/types"],
+      "@graphql-debugger/utils": ["../../packages/utils"]
     }
   },
   "references": [
-    { "path": "../opentelemetry" },
-    { "path": "../queue" },
-    { "path": "../schemas" },
-    { "path": "../time" },
-    { "path": "../types" },
-    { "path": "../utils" }
+    { "path": "../../packages/opentelemetry" },
+    { "path": "../../packages/queue" },
+    { "path": "../../packages/schemas" },
+    { "path": "../../packages/time" },
+    { "path": "../../packages/types" },
+    { "path": "../../packages/utils" }
   ]
 }

--- a/apps/collector-proxy/tsconfig.json
+++ b/apps/collector-proxy/tsconfig.json
@@ -10,12 +10,14 @@
     "paths": {
       "@graphql-debugger/schemas": ["../schemas"],
       "@graphql-debugger/time": ["../time"],
+      "@graphql-debugger/types": ["../types"],
       "@graphql-debugger/utils": ["../utils"]
     }
   },
   "references": [
     { "path": "../schemas" },
     { "path": "../time" },
+    { "path": "../types" },
     { "path": "../utils" }
   ],
   "exclude": ["tests/"],

--- a/apps/collector-proxy/tsconfig.json
+++ b/apps/collector-proxy/tsconfig.json
@@ -5,9 +5,9 @@
     "outDir": "build",
     "declarationMap": true,
     "declaration": true,
-    "rootDir": "./src/",
     "baseUrl": ".",
     "paths": {
+      "@graphql-debugger/queue": ["../queue"],
       "@graphql-debugger/schemas": ["../schemas"],
       "@graphql-debugger/time": ["../time"],
       "@graphql-debugger/types": ["../types"],
@@ -15,11 +15,10 @@
     }
   },
   "references": [
+    { "path": "../queue" },
     { "path": "../schemas" },
     { "path": "../time" },
     { "path": "../types" },
     { "path": "../utils" }
-  ],
-  "exclude": ["tests/"],
-  "include": ["src/**/*"]
+  ]
 }

--- a/apps/collector-proxy/tsconfig.json
+++ b/apps/collector-proxy/tsconfig.json
@@ -7,6 +7,7 @@
     "declaration": true,
     "baseUrl": ".",
     "paths": {
+      "@graphql-debugger/opentelemetry": ["../opentelemetry"],
       "@graphql-debugger/queue": ["../queue"],
       "@graphql-debugger/schemas": ["../schemas"],
       "@graphql-debugger/time": ["../time"],
@@ -15,6 +16,7 @@
     }
   },
   "references": [
+    { "path": "../opentelemetry" },
     { "path": "../queue" },
     { "path": "../schemas" },
     { "path": "../time" },

--- a/apps/collector-proxy/tsconfig.json
+++ b/apps/collector-proxy/tsconfig.json
@@ -2,15 +2,16 @@
   "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "target": "ES2020",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true,
     "outDir": "build",
     "declarationMap": true,
     "declaration": true,
-    "rootDir": "./src/"
+    "rootDir": "./src/",
+    "baseUrl": ".",
+    "paths": {
+      "@graphql-debugger/time": ["../time"]
+    }
   },
+  "references": [{ "path": "../time" }],
   "exclude": ["tests/"],
   "include": ["src/**/*"]
 }

--- a/apps/collector-proxy/tsconfig.test.json
+++ b/apps/collector-proxy/tsconfig.test.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "tests/"
-  },
-  "include": ["tests/**/*"]
-}

--- a/apps/landing-page/app/package.json
+++ b/apps/landing-page/app/package.json
@@ -34,5 +34,8 @@
   "engines": {
     "node": ">=18",
     "pnpm": ">=8"
+  },
+  "devDependencies": {
+    "tsconfig-paths-webpack-plugin": "^4.1.0"
   }
 }

--- a/apps/landing-page/app/tsconfig.json
+++ b/apps/landing-page/app/tsconfig.json
@@ -17,15 +17,15 @@
     "outDir": "build",
     "noEmit": false,
     "paths": {
-      "@graphql-debugger/time": ["../time"],
-      "@graphql-debugger/types": ["../types"],
-      "@graphql-debugger/utils": ["../utils"]
+      "@graphql-debugger/time": ["../../../packages/time"],
+      "@graphql-debugger/types": ["../../../packages/types"],
+      "@graphql-debugger/utils": ["../../../packages/utils"]
     }
   },
   "references": [
-    { "path": "../time" },
-    { "path": "../types" },
-    { "path": "../utils" }
+    { "path": "../../../packages/time" },
+    { "path": "../../../packages/types" },
+    { "path": "../../../packages/utils" }
   ],
   "include": ["src/**/*"]
 }

--- a/apps/landing-page/app/tsconfig.json
+++ b/apps/landing-page/app/tsconfig.json
@@ -17,9 +17,10 @@
     "outDir": "build",
     "noEmit": false,
     "paths": {
-      "@graphql-debugger/time": ["../time"]
+      "@graphql-debugger/time": ["../time"],
+      "@graphql-debugger/utils": ["../utils"]
     }
   },
-  "references": [{ "path": "../time" }],
+  "references": [{ "path": "../time" }, { "path": "../utils" }],
   "include": ["src/**/*"]
 }

--- a/apps/landing-page/app/tsconfig.json
+++ b/apps/landing-page/app/tsconfig.json
@@ -15,7 +15,11 @@
     "rootDir": "src",
     "baseUrl": ".",
     "outDir": "build",
-    "noEmit": false
+    "noEmit": false,
+    "paths": {
+      "@graphql-debugger/time": ["../time"]
+    }
   },
+  "references": [{ "path": "../time" }],
   "include": ["src/**/*"]
 }

--- a/apps/landing-page/app/tsconfig.json
+++ b/apps/landing-page/app/tsconfig.json
@@ -18,9 +18,14 @@
     "noEmit": false,
     "paths": {
       "@graphql-debugger/time": ["../time"],
+      "@graphql-debugger/types": ["../types"],
       "@graphql-debugger/utils": ["../utils"]
     }
   },
-  "references": [{ "path": "../time" }, { "path": "../utils" }],
+  "references": [
+    { "path": "../time" },
+    { "path": "../types" },
+    { "path": "../utils" }
+  ],
   "include": ["src/**/*"]
 }

--- a/apps/landing-page/app/webpack.config.js
+++ b/apps/landing-page/app/webpack.config.js
@@ -6,6 +6,7 @@ const TerserPlugin = require("terser-webpack-plugin");
 const CompressionPlugin = require("compression-webpack-plugin");
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 const NodePolyfillPlugin = require("node-polyfill-webpack-plugin");
+const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
 
 module.exports = {
   mode: "none",
@@ -14,6 +15,7 @@ module.exports = {
   target: "web",
   resolve: {
     extensions: [".ts", ".tsx", ".mjs", ".json", ".js"],
+    plugins: [new TsconfigPathsPlugin()],
   },
   ...(process.env.NODE_ENV === "production"
     ? {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -24,7 +24,6 @@
   },
   "dependencies": {
     "@fontsource/roboto": "5.0.8",
-    "@graphql-debugger/time": "workspace:^",
     "@graphql-debugger/utils": "workspace:^",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -28,11 +28,11 @@
     "react-dom": "18.2.0",
     "react-router-dom": "6.7.0"
   },
-  "devDependencies": {
-    "@graphql-debugger/types": "workspace:^"
-  },
   "engines": {
     "node": ">=18",
     "pnpm": ">=8"
+  },
+  "devDependencies": {
+    "tsconfig-paths-webpack-plugin": "^4.1.0"
   }
 }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -24,7 +24,6 @@
   },
   "dependencies": {
     "@fontsource/roboto": "5.0.8",
-    "@graphql-debugger/utils": "workspace:^",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-router-dom": "6.7.0"

--- a/apps/ui/tsconfig.json
+++ b/apps/ui/tsconfig.json
@@ -15,7 +15,15 @@
     "rootDir": "src",
     "baseUrl": ".",
     "outDir": "build",
-    "noEmit": false
+    "noEmit": false,
+    "paths": {
+      "@graphql-debugger/time": ["../../packages/time"],
+      "@graphql-debugger/types": ["../../packages/types"]
+    }
   },
+  "references": [
+    { "path": "../../packages/time" },
+    { "path": "../../packages/types" }
+  ],
   "include": ["src/**/*"]
 }

--- a/apps/ui/webpack.config.js
+++ b/apps/ui/webpack.config.js
@@ -6,6 +6,7 @@ const TerserPlugin = require("terser-webpack-plugin");
 const CompressionPlugin = require("compression-webpack-plugin");
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 const NodePolyfillPlugin = require("node-polyfill-webpack-plugin");
+const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
 
 module.exports = {
   mode: "none",
@@ -14,6 +15,7 @@ module.exports = {
   target: "web",
   resolve: {
     extensions: [".ts", ".tsx", ".mjs", ".json", ".js"],
+    plugins: [new TsconfigPathsPlugin()],
   },
   ...(process.env.NODE_ENV === "production"
     ? {

--- a/e2e/jest.config.js
+++ b/e2e/jest.config.js
@@ -1,3 +1,7 @@
+const { compilerOptions } = require("./tsconfig.json");
+const { pathsToModuleNameMapper } = require("ts-jest");
+
+/** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   modulePathIgnorePatterns: [
     "<rootDir>/build/",
@@ -6,9 +10,10 @@ module.exports = {
   ],
   testTimeout: 150000,
   setupFilesAfterEnv: ["<rootDir>/tests/setup.ts"],
-  globals: {
-    "ts-jest": {
-      tsconfig: "tsconfig.test.json",
-    },
+  transform: {
+    "\\.ts$": ["ts-jest", { tsconfig: "tsconfig.test.json" }],
   },
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
+    prefix: __dirname,
+  }),
 };

--- a/e2e/jest.config.js
+++ b/e2e/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
   testTimeout: 150000,
   setupFilesAfterEnv: ["<rootDir>/tests/setup.ts"],
   transform: {
-    "\\.ts$": ["ts-jest", { tsconfig: "tsconfig.test.json" }],
+    "\\.ts$": ["ts-jest"],
   },
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
     prefix: __dirname,

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/rocket-connect/graphql-debugger#readme",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "test": "cd ../apps/ui && pnpm run build && cd ../../e2e && NODE_ENV=test DEBUG=\"@graphql-debugger:*\" jest --runInBand"
   },
   "peerDependencies": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -19,7 +19,6 @@
     "graphql": "^16.0.0 || ^17.0.0"
   },
   "dependencies": {
-    "@graphql-debugger/utils": "workspace:^",
     "@graphql-debugger/ui": "workspace:^",
     "@graphql-debugger/backend": "workspace:^",
     "@graphql-debugger/trace-schema": "workspace:^",

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -9,12 +9,14 @@
     "paths": {
       "@graphql-debugger/schemas": ["../packages/schemas"],
       "@graphql-debugger/time": ["../packages/time"],
+      "@graphql-debugger/types": ["../packages/types"],
       "@graphql-debugger/utils": ["../packages/utils"]
     }
   },
   "references": [
     { "path": "../packages/schemas" },
     { "path": "../packages/time" },
+    { "path": "../packages/types" },
     { "path": "../packages/utils" }
   ]
 }

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -7,11 +7,13 @@
     "declaration": true,
     "baseUrl": ".",
     "paths": {
+      "@graphql-debugger/schemas": ["../packages/schemas"],
       "@graphql-debugger/time": ["../packages/time"],
       "@graphql-debugger/utils": ["../packages/utils"]
     }
   },
   "references": [
+    { "path": "../packages/schemas" },
     { "path": "../packages/time" },
     { "path": "../packages/utils" }
   ]

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -7,6 +7,7 @@
     "declaration": true,
     "baseUrl": ".",
     "paths": {
+      "@graphql-debugger/opentelemetry": ["../packages/opentelemetry"],
       "@graphql-debugger/queue": ["../packages/queue"],
       "@graphql-debugger/schemas": ["../packages/schemas"],
       "@graphql-debugger/time": ["../packages/time"],
@@ -15,6 +16,7 @@
     }
   },
   "references": [
+    { "path": "../packages/opentelemetry" },
     { "path": "../packages/queue" },
     { "path": "../packages/schemas" },
     { "path": "../packages/time" },

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -7,6 +7,7 @@
     "declaration": true,
     "baseUrl": ".",
     "paths": {
+      "@graphql-debugger/queue": ["../packages/queue"],
       "@graphql-debugger/schemas": ["../packages/schemas"],
       "@graphql-debugger/time": ["../packages/time"],
       "@graphql-debugger/types": ["../packages/types"],
@@ -14,6 +15,7 @@
     }
   },
   "references": [
+    { "path": "../packages/queue" },
     { "path": "../packages/schemas" },
     { "path": "../packages/time" },
     { "path": "../packages/types" },

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -2,12 +2,17 @@
   "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "target": "ES2020",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true,
     "outDir": "build",
     "declarationMap": true,
-    "declaration": true
-  }
+    "declaration": true,
+    "baseUrl": ".",
+    "paths": {
+      "@graphql-debugger/time": ["../packages/time"],
+      "@graphql-debugger/utils": ["../packages/utils"]
+    }
+  },
+  "references": [
+    { "path": "../packages/time" },
+    { "path": "../packages/utils" }
+  ]
 }

--- a/e2e/tsconfig.test.json
+++ b/e2e/tsconfig.test.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "tests/"
-  },
-  "include": ["tests/**/*"]
-}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "turbo build",
     "test:sequential": "pnpm recursive exec -- sh -c 'pnpm run test || (echo \"Tests failed!\" && exit 1)'",
     "test": "turbo test",
-    "clean": "find . -type d \\( -name \"node_modules\" -o -name \"build\" -o -name \".turbo\" \\) -exec rm -rf {} +",
+    "clean": "find . -type d \\( -name \"node_modules\" -o -name \"build\" -o -name \".turbo\" \\) -exec rm -rf {} + && find . -type f -name \"tsconfig.tsbuildinfo\" -delete",
     "lint": "eslint .",
     "format": "prettier --write ."
   },

--- a/packages/data-access/package.json
+++ b/packages/data-access/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/rocket-connect/graphql-debugger#readme",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "postinstall": "npx prisma generate && npx prisma db push",
     "test": "echo \"No tests\""
   },

--- a/packages/data-access/tsconfig.json
+++ b/packages/data-access/tsconfig.json
@@ -2,12 +2,13 @@
   "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "target": "ES2020",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true,
     "outDir": "build",
     "declarationMap": true,
-    "declaration": true
-  }
+    "declaration": true,
+    "baseUrl": ".",
+    "paths": {
+      "@graphql-debugger/utils": ["../utils"]
+    }
+  },
+  "references": [{ "path": "../utils" }]
 }

--- a/packages/graphql-debugger/package.json
+++ b/packages/graphql-debugger/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/rocket-connect/graphql-debugger#readme",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "start": "node build/index.js",
     "dev": "cross-env NODE_ENV=development ts-node ./src/index.ts",
     "test": "echo \"No tests\""

--- a/packages/graphql-debugger/package.json
+++ b/packages/graphql-debugger/package.json
@@ -20,7 +20,6 @@
     "test": "echo \"No tests\""
   },
   "dependencies": {
-    "@graphql-debugger/backend": "workspace:^",
-    "@graphql-debugger/utils": "workspace:^"
+    "@graphql-debugger/backend": "workspace:^"
   }
 }

--- a/packages/graphql-debugger/tsconfig.json
+++ b/packages/graphql-debugger/tsconfig.json
@@ -2,12 +2,13 @@
   "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "target": "ES2020",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true,
     "outDir": "build",
     "declarationMap": true,
-    "declaration": true
-  }
+    "declaration": true,
+    "baseUrl": ".",
+    "paths": {
+      "@graphql-debugger/utils": ["../utils"]
+    }
+  },
+  "references": [{ "path": "../utils" }]
 }

--- a/packages/graphql-schema/jest.config.js
+++ b/packages/graphql-schema/jest.config.js
@@ -10,7 +10,7 @@ module.exports = {
   ],
   setupFilesAfterEnv: ["<rootDir>/tests/setup.ts"],
   transform: {
-    "\\.ts$": ["ts-jest", { tsconfig: "tsconfig.test.json" }],
+    "\\.ts$": ["ts-jest"],
   },
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
     prefix: __dirname,

--- a/packages/graphql-schema/jest.config.js
+++ b/packages/graphql-schema/jest.config.js
@@ -1,14 +1,18 @@
+const { compilerOptions } = require("./tsconfig.json");
+const { pathsToModuleNameMapper } = require("ts-jest");
+
+/** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   modulePathIgnorePatterns: [
     "<rootDir>/build/",
     "<rootDir>/node_modules/",
     "<rootDir>/build/",
   ],
-  testTimeout: 150000,
   setupFilesAfterEnv: ["<rootDir>/tests/setup.ts"],
-  globals: {
-    "ts-jest": {
-      tsconfig: "tsconfig.test.json",
-    },
+  transform: {
+    "\\.ts$": ["ts-jest", { tsconfig: "tsconfig.test.json" }],
   },
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
+    prefix: __dirname,
+  }),
 };

--- a/packages/graphql-schema/package.json
+++ b/packages/graphql-schema/package.json
@@ -13,7 +13,7 @@
   },
   "homepage": "https://github.com/rocket-connect/graphql-debugger#readme",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc -b tsconfig.build.json",
     "test": "NODE_ENV=test jest --runInBand"
   },
   "peerDependencies": {

--- a/packages/graphql-schema/package.json
+++ b/packages/graphql-schema/package.json
@@ -13,7 +13,7 @@
   },
   "homepage": "https://github.com/rocket-connect/graphql-debugger#readme",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --project tsconfig.build.json",
     "test": "NODE_ENV=test jest --runInBand"
   },
   "peerDependencies": {
@@ -23,7 +23,6 @@
     "@graphql-debugger/data-access": "workspace:^",
     "@graphql-debugger/time": "workspace:^",
     "@graphql-debugger/trace-schema": "workspace:^",
-    "@graphql-debugger/types": "workspace:^",
     "@graphql-debugger/schemas": "workspace:^",
     "@graphql-debugger/utils": "workspace:^",
     "@graphql-debugger/collector-proxy": "workspace:^",

--- a/packages/graphql-schema/src/loaders/span.ts
+++ b/packages/graphql-schema/src/loaders/span.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@graphql-debugger/data-access";
 import { TimeStamp, UnixNanoTimeStamp } from "@graphql-debugger/time";
-import { Span } from "@graphql-debugger/types";
+import type { Span } from "@graphql-debugger/types";
 
 import DataLoader from "dataloader";
 

--- a/packages/graphql-schema/src/mutations/delete-traces.ts
+++ b/packages/graphql-schema/src/mutations/delete-traces.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@graphql-debugger/data-access";
-import {
+import type {
   DeleteTracesResponse,
   DeleteTracesWhere,
 } from "@graphql-debugger/types";

--- a/packages/graphql-schema/src/objects/index.ts
+++ b/packages/graphql-schema/src/objects/index.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AggregateSpansResponse,
   AggregateSpansWhere,
   DeleteTracesResponse,

--- a/packages/graphql-schema/src/objects/schema.ts
+++ b/packages/graphql-schema/src/objects/schema.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@graphql-debugger/data-access";
-import { Schema } from "@graphql-debugger/types";
+import type { Schema } from "@graphql-debugger/types";
 
 import { ObjectRef } from "@pothos/core";
 

--- a/packages/graphql-schema/src/objects/span.ts
+++ b/packages/graphql-schema/src/objects/span.ts
@@ -1,4 +1,4 @@
-import { Span } from "@graphql-debugger/types";
+import type { Span } from "@graphql-debugger/types";
 
 import { ObjectRef } from "@pothos/core";
 

--- a/packages/graphql-schema/src/objects/trace.ts
+++ b/packages/graphql-schema/src/objects/trace.ts
@@ -1,5 +1,5 @@
 import { UnixNanoTimeStamp } from "@graphql-debugger/time";
-import { Span, Trace } from "@graphql-debugger/types";
+import type { Span, Trace } from "@graphql-debugger/types";
 
 import { ObjectRef } from "@pothos/core";
 

--- a/packages/graphql-schema/src/queries/aggregate-spans.ts
+++ b/packages/graphql-schema/src/queries/aggregate-spans.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@graphql-debugger/data-access";
 import { TimeStamp, UnixNanoTimeStamp } from "@graphql-debugger/time";
-import {
+import type {
   AggregateSpansResponse,
   AggregateSpansWhere,
 } from "@graphql-debugger/types";

--- a/packages/graphql-schema/src/queries/list-schemas.ts
+++ b/packages/graphql-schema/src/queries/list-schemas.ts
@@ -1,5 +1,8 @@
 import { prisma } from "@graphql-debugger/data-access";
-import { ListSchemasResponse, ListSchemasWhere } from "@graphql-debugger/types";
+import type {
+  ListSchemasResponse,
+  ListSchemasWhere,
+} from "@graphql-debugger/types";
 
 import { InputRef, ObjectRef } from "@pothos/core";
 

--- a/packages/graphql-schema/src/queries/list-trace-groups.ts
+++ b/packages/graphql-schema/src/queries/list-trace-groups.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@graphql-debugger/data-access";
-import {
+import type {
   ListTraceGroupsResponse,
   ListTraceGroupsWhere,
 } from "@graphql-debugger/types";

--- a/packages/graphql-schema/tests/mutations/delete-traces.test.ts
+++ b/packages/graphql-schema/tests/mutations/delete-traces.test.ts
@@ -4,7 +4,7 @@ import {
   GraphQLOTELContext,
   traceSchema,
 } from "@graphql-debugger/trace-schema";
-import { DeleteTracesResponse } from "@graphql-debugger/types";
+import type { DeleteTracesResponse } from "@graphql-debugger/types";
 
 import { makeExecutableSchema } from "@graphql-tools/schema";
 import gql from "gql-tag";

--- a/packages/graphql-schema/tests/queries/aggregate-spans.test.ts
+++ b/packages/graphql-schema/tests/queries/aggregate-spans.test.ts
@@ -4,7 +4,7 @@ import {
   GraphQLOTELContext,
   traceSchema,
 } from "@graphql-debugger/trace-schema";
-import { AggregateSpansResponse } from "@graphql-debugger/types";
+import type { AggregateSpansResponse } from "@graphql-debugger/types";
 
 import { makeExecutableSchema } from "@graphql-tools/schema";
 import gql from "gql-tag";

--- a/packages/graphql-schema/tests/queries/list-schemas.test.ts
+++ b/packages/graphql-schema/tests/queries/list-schemas.test.ts
@@ -1,6 +1,6 @@
 import { createTestSchema } from "@graphql-debugger/data-access";
 import { ListSchemasResponseSchema } from "@graphql-debugger/schemas";
-import { ListSchemasResponse } from "@graphql-debugger/types";
+import type { ListSchemasResponse } from "@graphql-debugger/types";
 
 import gql from "gql-tag";
 

--- a/packages/graphql-schema/tests/queries/list-trace-groups.test.ts
+++ b/packages/graphql-schema/tests/queries/list-trace-groups.test.ts
@@ -4,7 +4,7 @@ import {
   GraphQLOTELContext,
   traceSchema,
 } from "@graphql-debugger/trace-schema";
-import { ListTraceGroupsResponse } from "@graphql-debugger/types";
+import type { ListTraceGroupsResponse } from "@graphql-debugger/types";
 
 import { makeExecutableSchema } from "@graphql-tools/schema";
 import gql from "gql-tag";

--- a/packages/graphql-schema/tsconfig.build.json
+++ b/packages/graphql-schema/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["tests/**/*"],
+  "include": ["src/**/*"]
+}

--- a/packages/graphql-schema/tsconfig.json
+++ b/packages/graphql-schema/tsconfig.json
@@ -5,19 +5,19 @@
     "outDir": "build",
     "declarationMap": true,
     "declaration": true,
-    "rootDir": "./src/",
     "baseUrl": ".",
     "paths": {
       "@graphql-debugger/schemas": ["../schemas"],
       "@graphql-debugger/time": ["../time"],
+      "@graphql-debugger/types": ["../types"],
       "@graphql-debugger/utils": ["../utils"]
     }
   },
   "references": [
     { "path": "../schemas" },
     { "path": "../time" },
+    { "path": "../types" },
     { "path": "../utils" }
   ],
-  "exclude": ["tests/"],
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "tests/**/*"]
 }

--- a/packages/graphql-schema/tsconfig.json
+++ b/packages/graphql-schema/tsconfig.json
@@ -7,6 +7,7 @@
     "declaration": true,
     "baseUrl": ".",
     "paths": {
+      "@graphql-debugger/queue": ["../queue"],
       "@graphql-debugger/schemas": ["../schemas"],
       "@graphql-debugger/time": ["../time"],
       "@graphql-debugger/types": ["../types"],
@@ -14,6 +15,7 @@
     }
   },
   "references": [
+    { "path": "../queue" },
     { "path": "../schemas" },
     { "path": "../time" },
     { "path": "../types" },

--- a/packages/graphql-schema/tsconfig.json
+++ b/packages/graphql-schema/tsconfig.json
@@ -8,11 +8,16 @@
     "rootDir": "./src/",
     "baseUrl": ".",
     "paths": {
+      "@graphql-debugger/schemas": ["../schemas"],
       "@graphql-debugger/time": ["../time"],
       "@graphql-debugger/utils": ["../utils"]
     }
   },
-  "references": [{ "path": "../time" }, { "path": "../utils" }],
+  "references": [
+    { "path": "../schemas" },
+    { "path": "../time" },
+    { "path": "../utils" }
+  ],
   "exclude": ["tests/"],
   "include": ["src/**/*"]
 }

--- a/packages/graphql-schema/tsconfig.json
+++ b/packages/graphql-schema/tsconfig.json
@@ -8,10 +8,11 @@
     "rootDir": "./src/",
     "baseUrl": ".",
     "paths": {
-      "@graphql-debugger/time": ["../time"]
+      "@graphql-debugger/time": ["../time"],
+      "@graphql-debugger/utils": ["../utils"]
     }
   },
-  "references": [{ "path": "../time" }],
+  "references": [{ "path": "../time" }, { "path": "../utils" }],
   "exclude": ["tests/"],
   "include": ["src/**/*"]
 }

--- a/packages/graphql-schema/tsconfig.json
+++ b/packages/graphql-schema/tsconfig.json
@@ -7,6 +7,7 @@
     "declaration": true,
     "baseUrl": ".",
     "paths": {
+      "@graphql-debugger/opentelemetry": ["../opentelemetry"],
       "@graphql-debugger/queue": ["../queue"],
       "@graphql-debugger/schemas": ["../schemas"],
       "@graphql-debugger/time": ["../time"],
@@ -15,6 +16,7 @@
     }
   },
   "references": [
+    { "path": "../opentelemetry" },
     { "path": "../queue" },
     { "path": "../schemas" },
     { "path": "../time" },

--- a/packages/graphql-schema/tsconfig.json
+++ b/packages/graphql-schema/tsconfig.json
@@ -2,15 +2,16 @@
   "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "target": "ES2020",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true,
     "outDir": "build",
     "declarationMap": true,
     "declaration": true,
-    "rootDir": "./src/"
+    "rootDir": "./src/",
+    "baseUrl": ".",
+    "paths": {
+      "@graphql-debugger/time": ["../time"]
+    }
   },
+  "references": [{ "path": "../time" }],
   "exclude": ["tests/"],
   "include": ["src/**/*"]
 }

--- a/packages/graphql-schema/tsconfig.test.json
+++ b/packages/graphql-schema/tsconfig.test.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "tests/"
-  },
-  "include": ["tests/**/*"]
-}

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -13,14 +13,13 @@
   },
   "homepage": "https://github.com/rocket-connect/graphql-debugger#readme",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "test": "cross-env NODE_ENV=test jest --runInBand"
   },
   "peerDependencies": {
     "graphql": "^16.0.0 || ^17.0.0"
   },
   "dependencies": {
-    "@graphql-debugger/utils": "workspace:^",
     "@opentelemetry/api": "1.6.0",
     "@opentelemetry/context-async-hooks": "1.15.2",
     "@opentelemetry/exporter-trace-otlp-http": "0.41.2",
@@ -32,7 +31,6 @@
     "@graphql-tools/utils": "10.0.6"
   },
   "devDependencies": {
-    "@graphql-debugger/types": "workspace:^",
     "@faker-js/faker": "8.0.2"
   }
 }

--- a/packages/opentelemetry/tsconfig.json
+++ b/packages/opentelemetry/tsconfig.json
@@ -2,14 +2,11 @@
   "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "target": "ES2020",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true,
     "outDir": "build",
+    "rootDir": "./src/",
     "declarationMap": true,
     "declaration": true,
-    "rootDir": "./src/"
+    "composite": true
   },
   "exclude": ["tests/"],
   "include": ["src/**/*"]

--- a/packages/opentelemetry/tsconfig.json
+++ b/packages/opentelemetry/tsconfig.json
@@ -6,8 +6,13 @@
     "rootDir": "./src/",
     "declarationMap": true,
     "declaration": true,
-    "composite": true
+    "composite": true,
+    "paths": {
+      "@graphql-debugger/types": ["../types"],
+      "@graphql-debugger/utils": ["../utils"]
+    }
   },
+  "references": [{ "path": "../types" }, { "path": "../utils" }],
   "exclude": ["tests/"],
   "include": ["src/**/*"]
 }

--- a/packages/queue/package.json
+++ b/packages/queue/package.json
@@ -19,7 +19,6 @@
     "test": "echo \"No tests\""
   },
   "dependencies": {
-    "@graphql-debugger/utils": "workspace:^",
     "fastq": "1.15.0"
   },
   "devDependencies": {}

--- a/packages/queue/package.json
+++ b/packages/queue/package.json
@@ -13,7 +13,7 @@
   },
   "homepage": "https://github.com/rocket-connect/graphql-debugger#readme",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "start": "node build/index.js",
     "dev": "NODE_ENV=development ts-node ./src/index.ts",
     "test": "echo \"No tests\""

--- a/packages/queue/tsconfig.json
+++ b/packages/queue/tsconfig.json
@@ -3,8 +3,10 @@
   "compilerOptions": {
     "target": "ES2020",
     "outDir": "build",
+    "rootDir": "./src",
     "declarationMap": true,
     "declaration": true,
+    "composite": true,
     "baseUrl": ".",
     "paths": {
       "@graphql-debugger/utils": ["../utils"]

--- a/packages/queue/tsconfig.json
+++ b/packages/queue/tsconfig.json
@@ -2,12 +2,13 @@
   "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "target": "ES2020",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true,
     "outDir": "build",
     "declarationMap": true,
-    "declaration": true
-  }
+    "declaration": true,
+    "baseUrl": ".",
+    "paths": {
+      "@graphql-debugger/utils": ["../utils"]
+    }
+  },
+  "references": [{ "path": "../utils" }]
 }

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -13,7 +13,7 @@
   },
   "homepage": "https://github.com/rocket-connect/graphql-debugger#readme",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "test": "echo \"No tests\""
   },
   "peerDependencies": {},

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -18,7 +18,6 @@
   },
   "peerDependencies": {},
   "dependencies": {
-    "@graphql-debugger/time": "workspace:^",
     "zod": "3.22.2"
   },
   "devDependencies": {}

--- a/packages/schemas/tsconfig.json
+++ b/packages/schemas/tsconfig.json
@@ -7,6 +7,7 @@
     "declarationMap": true,
     "declaration": true,
     "composite": true,
+    "baseUrl": ".",
     "paths": {
       "@graphql-debugger/time": ["../time"]
     }

--- a/packages/schemas/tsconfig.json
+++ b/packages/schemas/tsconfig.json
@@ -3,8 +3,10 @@
   "compilerOptions": {
     "target": "ES2020",
     "outDir": "build",
+    "rootDir": "./src",
     "declarationMap": true,
     "declaration": true,
+    "composite": true,
     "paths": {
       "@graphql-debugger/time": ["../time"]
     }

--- a/packages/schemas/tsconfig.json
+++ b/packages/schemas/tsconfig.json
@@ -2,12 +2,12 @@
   "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "target": "ES2020",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true,
     "outDir": "build",
     "declarationMap": true,
-    "declaration": true
-  }
+    "declaration": true,
+    "paths": {
+      "@graphql-debugger/time": ["../time"]
+    }
+  },
+  "references": [{ "path": "../time" }]
 }

--- a/packages/time/src/unix-nano.ts
+++ b/packages/time/src/unix-nano.ts
@@ -19,10 +19,6 @@ export class UnixNanoTimeStamp {
     this.input = input;
   }
 
-  public static newFn() {
-    return 1;
-  }
-
   public getBigInt(): bigint {
     return BigInt(this.input);
   }

--- a/packages/time/src/unix-nano.ts
+++ b/packages/time/src/unix-nano.ts
@@ -19,6 +19,10 @@ export class UnixNanoTimeStamp {
     this.input = input;
   }
 
+  public static newFn() {
+    return 1;
+  }
+
   public getBigInt(): bigint {
     return BigInt(this.input);
   }

--- a/packages/time/tsconfig.json
+++ b/packages/time/tsconfig.json
@@ -2,12 +2,10 @@
   "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "target": "ES2020",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true,
     "outDir": "build",
+    "rootDir": "./src",
     "declarationMap": true,
-    "declaration": true
+    "declaration": true,
+    "composite": true
   }
 }

--- a/packages/trace-directive/package.json
+++ b/packages/trace-directive/package.json
@@ -13,7 +13,7 @@
   },
   "homepage": "https://github.com/rocket-connect/graphql-debugger#readme",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc -b tsconfig.build.json",
     "test": "NODE_ENV=test jest"
   },
   "peerDependencies": {

--- a/packages/trace-directive/package.json
+++ b/packages/trace-directive/package.json
@@ -13,7 +13,7 @@
   },
   "homepage": "https://github.com/rocket-connect/graphql-debugger#readme",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --project tsconfig.build.json",
     "test": "NODE_ENV=test jest"
   },
   "peerDependencies": {

--- a/packages/trace-directive/tsconfig.build.json
+++ b/packages/trace-directive/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["tests/"],
+  "include": ["src/**/*"]
+}

--- a/packages/trace-directive/tsconfig.json
+++ b/packages/trace-directive/tsconfig.json
@@ -5,13 +5,11 @@
     "outDir": "build",
     "declarationMap": true,
     "declaration": true,
-    "rootDir": "./src/",
     "baseUrl": ".",
     "paths": {
+      "@graphql-debugger/opentelemetry": ["../opentelemetry"],
       "@graphql-debugger/utils": ["../utils"]
     }
   },
-  "references": [{ "path": "../utils" }],
-  "exclude": ["tests/"],
-  "include": ["src/**/*"]
+  "references": [{ "path": "../opentelemetry" }, { "path": "../utils" }]
 }

--- a/packages/trace-directive/tsconfig.json
+++ b/packages/trace-directive/tsconfig.json
@@ -2,15 +2,16 @@
   "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "target": "ES2020",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true,
     "outDir": "build",
     "declarationMap": true,
     "declaration": true,
-    "rootDir": "./src/"
+    "rootDir": "./src/",
+    "baseUrl": ".",
+    "paths": {
+      "@graphql-debugger/utils": ["../utils"]
+    }
   },
+  "references": [{ "path": "../utils" }],
   "exclude": ["tests/"],
   "include": ["src/**/*"]
 }

--- a/packages/trace-directive/tsconfig.test.json
+++ b/packages/trace-directive/tsconfig.test.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "tests/"
-  },
-  "include": ["tests/**/*"]
-}

--- a/packages/trace-schema/package.json
+++ b/packages/trace-schema/package.json
@@ -13,7 +13,7 @@
   },
   "homepage": "https://github.com/rocket-connect/graphql-debugger#readme",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "test": "cross-env NODE_ENV=test jest"
   },
   "peerDependencies": {

--- a/packages/trace-schema/tsconfig.json
+++ b/packages/trace-schema/tsconfig.json
@@ -8,10 +8,11 @@
     "rootDir": "./src/",
     "baseUrl": ".",
     "paths": {
+      "@graphql-debugger/types": ["../types"],
       "@graphql-debugger/utils": ["../utils"]
     }
   },
-  "references": [{ "path": "../utils" }],
+  "references": [{ "path": "../types" }, { "path": "../utils" }],
   "exclude": ["tests/"],
   "include": ["src/**/*"]
 }

--- a/packages/trace-schema/tsconfig.json
+++ b/packages/trace-schema/tsconfig.json
@@ -2,15 +2,16 @@
   "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "target": "ES2020",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true,
     "outDir": "build",
     "declarationMap": true,
     "declaration": true,
-    "rootDir": "./src/"
+    "rootDir": "./src/",
+    "baseUrl": ".",
+    "paths": {
+      "@graphql-debugger/utils": ["../utils"]
+    }
   },
+  "references": [{ "path": "../utils" }],
   "exclude": ["tests/"],
   "include": ["src/**/*"]
 }

--- a/packages/trace-schema/tsconfig.json
+++ b/packages/trace-schema/tsconfig.json
@@ -8,11 +8,16 @@
     "rootDir": "./src/",
     "baseUrl": ".",
     "paths": {
+      "@graphql-debugger/opentelemetry": ["../opentelemetry"],
       "@graphql-debugger/types": ["../types"],
       "@graphql-debugger/utils": ["../utils"]
     }
   },
-  "references": [{ "path": "../types" }, { "path": "../utils" }],
+  "references": [
+    { "path": "../opentelemetry" },
+    { "path": "../types" },
+    { "path": "../utils" }
+  ],
   "exclude": ["tests/"],
   "include": ["src/**/*"]
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -13,7 +13,7 @@
   },
   "homepage": "https://github.com/rocket-connect/graphql-debugger#readme",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "test": "echo \"No tests\""
   },
   "peerDependencies": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -18,8 +18,5 @@
   },
   "peerDependencies": {
     "graphql": "^16.0.0 || ^17.0.0"
-  },
-  "devDependencies": {
-    "@graphql-debugger/schemas": "workspace:^"
   }
 }

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -2,12 +2,13 @@
   "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "target": "ES2020",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true,
     "outDir": "build",
     "declarationMap": true,
-    "declaration": true
-  }
+    "declaration": true,
+    "baseUrl": ".",
+    "paths": {
+      "@graphql-debugger/schemas": ["../schemas"]
+    }
+  },
+  "references": [{ "path": "../schemas" }]
 }

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -3,8 +3,10 @@
   "compilerOptions": {
     "target": "ES2020",
     "outDir": "build",
+    "rootDir": "./src",
     "declarationMap": true,
     "declaration": true,
+    "composite": true,
     "baseUrl": ".",
     "paths": {
       "@graphql-debugger/schemas": ["../schemas"]

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -2,12 +2,10 @@
   "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "target": "ES2020",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true,
     "outDir": "build",
+    "rootDir": "./src",
     "declarationMap": true,
-    "declaration": true
+    "declaration": true,
+    "composite": true
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,9 +217,6 @@ importers:
       '@faker-js/faker':
         specifier: 8.0.2
         version: 8.0.2
-      '@graphql-debugger/types':
-        specifier: workspace:^
-        version: link:../../packages/types
 
   apps/landing-page/app:
     dependencies:
@@ -376,9 +373,6 @@ importers:
       '@graphql-debugger/trace-schema':
         specifier: workspace:^
         version: link:../trace-schema
-      '@graphql-debugger/types':
-        specifier: workspace:^
-        version: link:../types
       '@graphql-debugger/utils':
         specifier: workspace:^
         version: link:../utils

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,9 +170,6 @@ importers:
       '@graphql-debugger/ui':
         specifier: workspace:^
         version: link:../ui
-      '@graphql-debugger/utils':
-        specifier: workspace:^
-        version: link:../../packages/utils
       cors:
         specifier: 2.8.5
         version: 2.8.5
@@ -207,9 +204,6 @@ importers:
       '@graphql-debugger/trace-schema':
         specifier: workspace:^
         version: link:../../packages/trace-schema
-      '@graphql-debugger/utils':
-        specifier: workspace:^
-        version: link:../../packages/utils
       '@graphql-tools/schema':
         specifier: 10.0.0
         version: 10.0.0(graphql@16.0.0)
@@ -290,9 +284,6 @@ importers:
       '@fontsource/roboto':
         specifier: 5.0.8
         version: 5.0.8
-      '@graphql-debugger/utils':
-        specifier: workspace:^
-        version: link:../../packages/utils
       graphql:
         specifier: ^16.0.0 || ^17.0.0
         version: 16.0.0
@@ -324,9 +315,6 @@ importers:
       '@graphql-debugger/ui':
         specifier: workspace:^
         version: link:../apps/ui
-      '@graphql-debugger/utils':
-        specifier: workspace:^
-        version: link:../packages/utils
       '@graphql-tools/schema':
         specifier: 10.0.0
         version: 10.0.0(graphql@16.0.0)
@@ -373,9 +361,6 @@ importers:
       '@graphql-debugger/backend':
         specifier: workspace:^
         version: link:../../apps/backend
-      '@graphql-debugger/utils':
-        specifier: workspace:^
-        version: link:../utils
 
   packages/graphql-schema:
     dependencies:
@@ -471,9 +456,6 @@ importers:
 
   packages/queue:
     dependencies:
-      '@graphql-debugger/utils':
-        specifier: workspace:^
-        version: link:../utils
       fastq:
         specifier: 1.15.0
         version: 1.15.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,9 +198,6 @@ importers:
       '@graphql-debugger/queue':
         specifier: workspace:^
         version: link:../../packages/queue
-      '@graphql-debugger/schemas':
-        specifier: workspace:^
-        version: link:../../packages/schemas
       '@graphql-debugger/trace-schema':
         specifier: workspace:^
         version: link:../../packages/trace-schema
@@ -529,10 +526,6 @@ importers:
       graphql:
         specifier: ^16.0.0 || ^17.0.0
         version: 16.8.0
-    devDependencies:
-      '@graphql-debugger/schemas':
-        specifier: workspace:^
-        version: link:../schemas
 
   packages/utils:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,9 +204,6 @@ importers:
       '@graphql-debugger/schemas':
         specifier: workspace:^
         version: link:../../packages/schemas
-      '@graphql-debugger/time':
-        specifier: workspace:^
-        version: link:../../packages/time
       '@graphql-debugger/trace-schema':
         specifier: workspace:^
         version: link:../../packages/trace-schema
@@ -293,9 +290,6 @@ importers:
       '@fontsource/roboto':
         specifier: 5.0.8
         version: 5.0.8
-      '@graphql-debugger/time':
-        specifier: workspace:^
-        version: link:../../packages/time
       '@graphql-debugger/utils':
         specifier: workspace:^
         version: link:../../packages/utils
@@ -486,9 +480,6 @@ importers:
 
   packages/schemas:
     dependencies:
-      '@graphql-debugger/time':
-        specifier: workspace:^
-        version: link:../time
       zod:
         specifier: 3.22.2
         version: 3.22.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,6 +244,10 @@ importers:
       tailwind-merge:
         specifier: ^1.14.0
         version: 1.14.0
+    devDependencies:
+      tsconfig-paths-webpack-plugin:
+        specifier: ^4.1.0
+        version: 4.1.0
 
   apps/landing-page/server:
     dependencies:
@@ -285,9 +289,9 @@ importers:
         specifier: 6.7.0
         version: 6.7.0(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
-      '@graphql-debugger/types':
-        specifier: workspace:^
-        version: link:../../packages/types
+      tsconfig-paths-webpack-plugin:
+        specifier: ^4.1.0
+        version: 4.1.0
 
   e2e:
     dependencies:
@@ -398,9 +402,6 @@ importers:
 
   packages/opentelemetry:
     dependencies:
-      '@graphql-debugger/utils':
-        specifier: workspace:^
-        version: link:../utils
       '@graphql-tools/schema':
         specifier: 10.0.0
         version: 10.0.0(graphql@16.0.0)
@@ -435,9 +436,6 @@ importers:
       '@faker-js/faker':
         specifier: 8.0.2
         version: 8.0.2
-      '@graphql-debugger/types':
-        specifier: workspace:^
-        version: link:../types
 
   packages/queue:
     dependencies:
@@ -9492,11 +9490,29 @@ packages:
       yn: 3.1.1
     dev: true
 
+  /tsconfig-paths-webpack-plugin@4.1.0:
+    resolution: {integrity: sha512-xWFISjviPydmtmgeUAuXp4N1fky+VCtfhOkDUFIv5ea7p4wuTomI4QTrXvFBX2S4jZsmyTSrStQl+E+4w+RzxA==}
+    engines: {node: '>=10.13.0'}
+    dependencies:
+      chalk: 4.1.2
+      enhanced-resolve: 5.15.0
+      tsconfig-paths: 4.2.0
+    dev: true
+
   /tsconfig-paths@3.14.2:
     resolution: {integrity: sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==}
     dependencies:
       '@types/json5': 0.0.29
       json5: 1.0.2
+      minimist: 1.2.8
+      strip-bom: 3.0.0
+    dev: true
+
+  /tsconfig-paths@4.2.0:
+    resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
+    engines: {node: '>=6'}
+    dependencies:
+      json5: 2.2.3
       minimist: 1.2.8
       strip-bom: 3.0.0
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,9 +195,6 @@ importers:
       '@graphql-debugger/opentelemetry':
         specifier: workspace:^
         version: link:../../packages/opentelemetry
-      '@graphql-debugger/queue':
-        specifier: workspace:^
-        version: link:../../packages/queue
       '@graphql-debugger/trace-schema':
         specifier: workspace:^
         version: link:../../packages/trace-schema

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,9 +192,6 @@ importers:
       '@graphql-debugger/data-access':
         specifier: workspace:^
         version: link:../../packages/data-access
-      '@graphql-debugger/opentelemetry':
-        specifier: workspace:^
-        version: link:../../packages/opentelemetry
       '@graphql-debugger/trace-schema':
         specifier: workspace:^
         version: link:../../packages/trace-schema


### PR DESCRIPTION
Project References in our app make it faster to develop multiple packages at once. For example, consider you want to create a function in the `time` package and consume it in `ui`; here are the current and proposed workflows;

**Current**
1. Add your function and tests to `time`
2. Run `pnpm build` over the whole app (~30s on modern machines)
3. Consume the function in `ui` (which may also require restarting your IDE's TS Server)

**Proposed**
1. Add your function and tests to `time`
2. Consume the function in `ui` (the IDE TS Server won't need to be restarted)

This should make the developer experience a lot faster and simpler