### PR TITLE
fix: add ssh timeout

### DIFF
--- a/.github/workflows/deploy-landing-page.yml
+++ b/.github/workflows/deploy-landing-page.yml
@@ -13,6 +13,7 @@ jobs:
       - name: SSH and deploy node app
         uses: appleboy/ssh-action@master
         with:
+          timeout: 60s
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USERNAME }}
           key: ${{ secrets.SSH_KEY }}


### PR DESCRIPTION
Testing out the landing page deployment with a higher timeout as the build was taking longer then 30s crashing the ssh connection resulting in a half built application.