### PR TITLE
refactor: remove client from entry

### DIFF
--- a/docs/src/pages/docs/how.mdx
+++ b/docs/src/pages/docs/how.mdx
@@ -89,7 +89,6 @@ Using Trace Schema you can automatically add the Trace Directive to your schema 
 
 ```ts
 import { traceSchema } from '@graphql-debugger/trace-schema';
-import { DebuggerClient } from '@graphql-debugger/client';
 import { makeExecutableSchema } from 'graphql-tools';
 
 const typeDefs = `
@@ -116,7 +115,7 @@ const schema = makeExecutableSchema({
 // Schema with tracing applied to all fields
 const tracedSchema = traceSchema({
     schema,
-    client: DebuggerClient // <-- See Client and Adapters
+    adapter: // <-- See Adapters
 });
 ````
 
@@ -207,7 +206,7 @@ const tracedSchema = traceSchema({
 
 // or
 const tracedSchema = traceSchema({
-schema,
+  schema,
 });
 
 ```

--- a/docs/src/pages/docs/how.mdx
+++ b/docs/src/pages/docs/how.mdx
@@ -166,6 +166,7 @@ When using Trace Schema, in the background, the schema will be hashed and export
 ```ts
 const tracedSchema = traceSchema({
   schema,
+  adapter,
   shouldExportSchema: false, // <-- Disable schema export
 });
 ```
@@ -179,6 +180,7 @@ Alongside the Schema Exporter mechanism, Trace Schema will also setup the nessar
 ```ts
 const tracedSchema = traceSchema({
     schema,
+    adapter,
     exporterConfig: {
         url: 'https://trace-api.newrelic.com/trace/v1',
     }
@@ -189,6 +191,7 @@ const tracedSchema = traceSchema({
 ```ts
 const tracedSchema = traceSchema({
     schema,
+    adapter,
     exporterConfig: {
         url: 'https://trace.agent.datadoghq.com/v0.4/traces',
     }
@@ -199,6 +202,7 @@ const tracedSchema = traceSchema({
 ```ts
 const tracedSchema = traceSchema({
     schema,
+    adapter,
     exporterConfig: {
         url: 'http://localhost:4318/v1/traces',
     }
@@ -207,6 +211,7 @@ const tracedSchema = traceSchema({
 // or
 const tracedSchema = traceSchema({
   schema,
+  adapter,
 });
 
 ```

--- a/docs/src/pages/docs/index.mdx
+++ b/docs/src/pages/docs/index.mdx
@@ -52,7 +52,6 @@ Once debugger is running you can use our open source packages to connect your Gr
 
 ```ts
 import { ProxyAdapter } from "@graphql-debugger/adapter-proxy";
-import { DebuggerClient } from "@graphql-debugger/client";
 import { traceSchema } from "@graphql-debugger/trace-schema";
 
 import { GraphQLSchema } from "graphql";
@@ -61,13 +60,9 @@ const schema: GraphQLSchema = __YOUR_SCHEMA__;
 
 const adapter = new ProxyAdapter();
 
-const client = new DebuggerClient({
-  adapter,
-});
-
 const tracedSchema = traceSchema({
   schema,
-  client,
+  adapter,
 });
 ```
 
@@ -75,7 +70,6 @@ const tracedSchema = traceSchema({
 
 ```ts
 import { ProxyAdapter } from "@graphql-debugger/adapter-proxy";
-import { DebuggerClient } from "@graphql-debugger/client";
 import {
   GraphQLDebuggerContext,
   traceSchema,
@@ -91,13 +85,9 @@ const schema = makeExecutableSchema({
 
 const adapter = new ProxyAdapter();
 
-const client = new DebuggerClient({
-  adapter,
-});
-
 const tracedSchema = traceSchema({
   schema,
-  client,
+  adapter,
 });
 
 const yoga = createYoga({

--- a/e2e/tests/utils/create-test-schema.ts
+++ b/e2e/tests/utils/create-test-schema.ts
@@ -65,7 +65,7 @@ export async function createTestSchema({
 
   const schema = traceSchema({
     schema: executableSchema,
-    client,
+    adapter: client.adapter,
   });
 
   const hash = hashSchema(schema);

--- a/packages/graphql-schema/src/schema.ts
+++ b/packages/graphql-schema/src/schema.ts
@@ -25,7 +25,7 @@ const build = builder.toSchema();
 export function createSchema({ client }: { client: DebuggerClient }) {
   const schema = TRACE_SCHEMA
     ? traceSchema({
-        client,
+        adapter: client.adapter,
         schema: build,
         ...(TRACE_PRISMA && {
           instrumentations: [tracing],

--- a/packages/trace-schema/README.md
+++ b/packages/trace-schema/README.md
@@ -4,53 +4,6 @@
 
 [![npm version](https://badge.fury.io/js/@graphql-debugger%2Ftrace-schema.svg)](https://badge.fury.io/js/@graphql-debugger%2Ftrace-schema) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-## About
-
-Trace Schema wraps each field in your GraphQL schema with the [trace directive](https://github.com/rocket-connect/graphql-otel).
-
-This directive wraps a resolver in a span.
-
-Once the schema is traced it posts your GraphQL schema to the [GraphQL Debugger collector](https://github.com/rocket-connect/graphql-debugger/tree/main/packages/collector-proxy).
-
-Finally, it sets up the nessessary OpenTelemetry instrumentation packages and propagators so that each trace is exported to the [collector](https://github.com/rocket-connect/graphql-debugger/tree/main/packages/collector-proxy).
-
-## Usage
-
-```ts
-import {
-  GraphQLDebuggerContext,
-  traceSchema,
-} from "@graphql-debugger/trace-schema";
-
-import { makeExecutableSchema } from "@graphql-tools/schema";
-import { createYoga } from "graphql-yoga";
-
-// Common GraphQL schema
-const schema = makeExecutableSchema({
-  typeDefs,
-  resolvers,
-});
-
-// Wrap all resolvers and fields with tracing
-const tracedSchema = traceSchema({
-  schema,
-});
-
-const yoga = createYoga({
-  schema: tracedSchema,
-  context: (req) => {
-    return {
-      // Include variables, result and context in traces
-      GraphQLDebuggerContext: new GraphQLDebuggerContext({
-        includeVariables: true,
-        includeResult: true,
-        includeContext: true,
-      }),
-    };
-  },
-});
-```
-
 ## License
 
 MIT - Rocket Connect - https://github.com/rocket-connect

--- a/packages/trace-schema/package.json
+++ b/packages/trace-schema/package.json
@@ -21,12 +21,15 @@
   },
   "dependencies": {
     "@graphql-debugger/client": "workspace:^",
-    "@graphql-debugger/adapter-sqlite": "workspace:^",
+    "@graphql-debugger/adapter-base": "workspace:^",
     "@graphql-debugger/opentelemetry": "workspace:^",
     "@graphql-debugger/trace-directive": "workspace:^",
-    "@graphql-debugger/types": "workspace:^",
     "@graphql-debugger/utils": "workspace:^",
     "@graphql-tools/schema": "10.0.2",
     "@graphql-tools/utils": "10.0.11"
+  },
+  "devDependencies": {
+    "@graphql-debugger/adapter-sqlite": "workspace:^",
+    "@graphql-debugger/types": "workspace:^"
   }
 }

--- a/packages/trace-schema/src/index.ts
+++ b/packages/trace-schema/src/index.ts
@@ -1,3 +1,4 @@
+import { BaseAdapter } from "@graphql-debugger/adapter-base";
 import { DebuggerClient } from "@graphql-debugger/client";
 import { SetupOtelInput, setupOtel } from "@graphql-debugger/opentelemetry";
 import { traceDirective } from "@graphql-debugger/trace-directive";
@@ -19,7 +20,7 @@ import { SchemaExporer } from "./schema-exporter";
 
 export interface TraceSchemaInput {
   schema: GraphQLSchema;
-  client: DebuggerClient;
+  adapter: BaseAdapter;
   exporterConfig?: SetupOtelInput["exporterConfig"];
   instrumentations?: SetupOtelInput["instrumentations"];
   shouldExportSchema?: boolean;
@@ -28,7 +29,7 @@ export interface TraceSchemaInput {
 export function traceSchema({
   schema,
   exporterConfig,
-  client,
+  adapter,
   instrumentations,
   shouldExportSchema = true,
 }: TraceSchemaInput): GraphQLSchema {
@@ -78,6 +79,9 @@ export function traceSchema({
   );
 
   if (shouldExportSchema) {
+    const client = new DebuggerClient({
+      adapter,
+    });
     const schemaExporer = new SchemaExporer({
       schema: tracedSchema,
       client,

--- a/packages/trace-schema/tests/trace-schema.test.ts
+++ b/packages/trace-schema/tests/trace-schema.test.ts
@@ -1,5 +1,3 @@
-import { DebuggerClient } from "@graphql-debugger/client";
-
 import { makeExecutableSchema } from "@graphql-tools/schema";
 import { printSchemaWithDirectives } from "@graphql-tools/utils";
 
@@ -30,11 +28,10 @@ describe("tracedSchema", () => {
     });
 
     const adapter = new SQLiteAdapter();
-    const client = new DebuggerClient({ adapter });
 
     const tracedSchema = traceSchema({
       schema,
-      client,
+      adapter,
       shouldExportSchema: false,
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -687,9 +687,9 @@ importers:
 
   packages/trace-schema:
     dependencies:
-      '@graphql-debugger/adapter-sqlite':
+      '@graphql-debugger/adapter-base':
         specifier: workspace:^
-        version: link:../adapters/sqlite
+        version: link:../adapters/base
       '@graphql-debugger/client':
         specifier: workspace:^
         version: link:../client
@@ -699,9 +699,6 @@ importers:
       '@graphql-debugger/trace-directive':
         specifier: workspace:^
         version: link:../trace-directive
-      '@graphql-debugger/types':
-        specifier: workspace:^
-        version: link:../types
       '@graphql-debugger/utils':
         specifier: workspace:^
         version: link:../utils
@@ -714,6 +711,13 @@ importers:
       graphql:
         specifier: ^16.0.0 || ^17.0.0
         version: 16.0.0
+    devDependencies:
+      '@graphql-debugger/adapter-sqlite':
+        specifier: workspace:^
+        version: link:../adapters/sqlite
+      '@graphql-debugger/types':
+        specifier: workspace:^
+        version: link:../types
 
   packages/types:
     dependencies:


### PR DESCRIPTION
This removes need to supply the client when using`traceSchema`.