### PR TITLE
fix: remove schema hashing each request

### DIFF
--- a/docs/src/pages/docs/_meta.ts
+++ b/docs/src/pages/docs/_meta.ts
@@ -7,4 +7,5 @@ export default {
   plugins: "Plugins",
   integrations: "Integrations",
   docker: "Docker",
+  faq: "FAQ",
 };

--- a/docs/src/pages/docs/faq/missing-context.mdx
+++ b/docs/src/pages/docs/faq/missing-context.mdx
@@ -1,0 +1,18 @@
+# Missing Context
+
+> `contextValue.GraphQLDebuggerContext missing`
+
+Inject the `GraphQLDebuggerContext` instance inside your GraphQL request context.
+
+```js
+import { GraphQLDebuggerContext } from "@graphql-debugger/trace-schema";
+
+const myServer = new GraphQLServerFooBar({
+  schema,
+  context: {
+    GraphQLDebuggerContext: new GraphQLDebuggerContext({
+      schema,
+    }),
+  },
+});
+```

--- a/docs/src/pages/docs/packages/trace-directive.mdx
+++ b/docs/src/pages/docs/packages/trace-directive.mdx
@@ -1,0 +1,65 @@
+# @graphql-debugger/trace-directive
+
+Utility to trace a GraphQL Field. You can apply it to a field in your schema to trace it.
+
+## Quickstart
+
+First you should apply the directive to your type definitions and then run the transformer on your schema.
+
+### Apply Directive to schema
+
+```gql
+type User {
+    name: String
+    age: Int
+    balance: Int @trace
+    posts: [Post] @trace
+}
+
+type Post {
+    title: String
+    comments: [Comment] @trace
+}
+
+type Comment {
+    content: String
+}
+
+type Query {
+    users: [User] @trace
+}
+```
+
+### Run transformer
+
+```ts
+import {
+  GraphQLDebuggerContext,
+  setupOtel,
+  traceDirective,
+} from "@graphql-debugger/trace-directive";
+
+import { makeExecutableSchema } from "@graphql-tools/schema";
+import { createServer } from "@graphql-yoga/node";
+
+setupOtel(); // Setup OpenTelemetry Propagators
+
+const trace = traceDirective();
+
+let schema = makeExecutableSchema({
+  typeDefs: [typeDefs, trace.typeDefs],
+  resolvers,
+});
+
+schema = trace.transformer(schema);
+
+const server = createServer({
+  schema,
+  port: 5000,
+  context: {
+    GraphQLDebuggerContext: new GraphQLDebuggerContext({
+      schema,
+    }),
+  },
+});
+```

--- a/docs/src/pages/docs/packages/trace-schema.mdx
+++ b/docs/src/pages/docs/packages/trace-schema.mdx
@@ -1,0 +1,21 @@
+# @graphql-debugger/trace-schema
+
+Use the `traceSchema` method to automaticly apply the [`traceDirective`](/docs/packages/trace-directive) to all fields in your schema. 
+
+## Example
+
+```ts
+import { ProxyAdapter } from "@graphql-debugger/adapter-proxy";
+import { traceSchema } from "@graphql-debugger/trace-schema";
+
+import { GraphQLSchema } from "graphql";
+
+const schema: GraphQLSchema = __YOUR_SCHEMA__;
+
+const adapter = new ProxyAdapter();
+
+const tracedSchema = traceSchema({
+  schema,
+  adapter,
+});
+```

--- a/e2e/tests/utils/query-schema.ts
+++ b/e2e/tests/utils/query-schema.ts
@@ -14,9 +14,7 @@ export async function querySchema({
     source: query,
     contextValue: {
       GraphQLDebuggerContext: new GraphQLDebuggerContext({
-        includeResult: true,
-        includeContext: true,
-        includeVariables: true,
+        schema,
       }),
     },
   });

--- a/packages/graphql-schema/src/context.ts
+++ b/packages/graphql-schema/src/context.ts
@@ -1,6 +1,8 @@
 import { DebuggerClient } from "@graphql-debugger/client";
 import { GraphQLDebuggerContext } from "@graphql-debugger/trace-schema";
 
+import { GraphQLSchema } from "graphql";
+
 import { rootSpanLoader, spanLoader } from "./loaders/span";
 
 export type Context = {
@@ -12,13 +14,17 @@ export type Context = {
   };
 };
 
-export function context({ client }: { client: DebuggerClient }): () => Context {
+export function context({
+  client,
+  schema,
+}: {
+  client: DebuggerClient;
+  schema: GraphQLSchema;
+}): () => Context {
   return (): Context => {
     return {
       GraphQLDebuggerContext: new GraphQLDebuggerContext({
-        includeVariables: true,
-        // includeResult: true, 08/10/2023 - disabled to avoid memory related issues
-        // includeContext: true, ditto
+        schema,
       }),
       client,
       loaders: {

--- a/packages/graphql-schema/src/index.ts
+++ b/packages/graphql-schema/src/index.ts
@@ -10,6 +10,6 @@ export function createServer({ client }: { client: DebuggerClient }) {
 
   return createYoga({
     schema,
-    context: context({ client }),
+    context: context({ client, schema }),
   });
 }

--- a/packages/opentelemetry/src/info-to-attributes.ts
+++ b/packages/opentelemetry/src/info-to-attributes.ts
@@ -21,6 +21,7 @@ export function infoToAttributes({
     ...(isRoot
       ? {
           [AttributeNames.OPERATION_ROOT]: true,
+          // Note
           [AttributeNames.DOCUMENT]: print(info.operation),
           [AttributeNames.OPERATION_TYPE]:
             info.operation.operation.toLowerCase(),

--- a/packages/trace-directive/README.md
+++ b/packages/trace-directive/README.md
@@ -160,7 +160,9 @@ const server = createServer({
   schema,
   port: 5000,
   context: {
-    GraphQLDebuggerContext: new GraphQLDebuggerContext(),
+    GraphQLDebuggerContext: new GraphQLDebuggerContext({
+      schema,
+    }),
   },
 });
 
@@ -180,7 +182,9 @@ import { GraphQLDebuggerContext } from "@graphql-debugger/trace-directive";
 const myServer = new GraphQLServerFooBar({
   schema,
   context: {
-    GraphQLDebuggerContext: new GraphQLDebuggerContext(),
+    GraphQLDebuggerContext: new GraphQLDebuggerContext({
+      schema,
+    }),
   },
 });
 ```

--- a/packages/trace-directive/src/context.ts
+++ b/packages/trace-directive/src/context.ts
@@ -11,32 +11,19 @@ import { hashSchema } from "@graphql-debugger/utils";
 import { GraphQLSchema } from "graphql";
 
 export interface GraphQLDebuggerContextOptions {
-  /* If true will add the context in the span attributes */
-  includeContext?: boolean;
-  /* If true will add the variables in the span attributes */
-  includeVariables?: boolean;
-  /* If true will add the result in the span attributes */
-  includeResult?: boolean;
-  /* List of strings to exclude from the context, for example auth */
-  excludeKeysFromContext?: string[];
+  schema: GraphQLSchema;
 }
 
 export class GraphQLDebuggerContext {
   private context?: Context;
   public tracer: Tracer;
   private rootSpan?: ApiSpan;
-  public includeContext?: boolean;
-  public includeVariables?: boolean;
-  public includeResult?: boolean;
-  public excludeKeysFromContext?: string[];
-  public schema?: GraphQLSchema;
-  public schemaHash?: string;
+  public schema: GraphQLSchema;
+  public schemaHash: string;
 
-  constructor(options: GraphQLDebuggerContextOptions = {}) {
-    this.includeContext = options.includeContext;
-    this.includeVariables = options.includeVariables;
-    this.excludeKeysFromContext = options.excludeKeysFromContext;
-    this.includeResult = options.includeResult;
+  constructor(options: GraphQLDebuggerContextOptions) {
+    this.schema = options.schema;
+    this.schemaHash = hashSchema(options.schema);
     this.tracer = getTracer();
   }
 
@@ -54,13 +41,6 @@ export class GraphQLDebuggerContext {
 
   getRootSpan(): ApiSpan | undefined {
     return this.rootSpan;
-  }
-
-  public setSchema(schema: GraphQLSchema) {
-    const hash = hashSchema(schema);
-
-    this.schemaHash = hash;
-    this.schema = schema;
   }
 
   runInChildSpan(input: {

--- a/packages/trace-directive/src/trace-directive.ts
+++ b/packages/trace-directive/src/trace-directive.ts
@@ -40,10 +40,6 @@ export function traceDirective(directiveName = "trace") {
                 throw new Error("contextValue.GraphQLDebuggerContext missing");
               }
 
-              if (!internalCtx.schema) {
-                internalCtx.setSchema(schema);
-              }
-
               const parentContext = internalCtx
                 ? internalCtx.getContext()
                 : undefined;

--- a/packages/trace-directive/tests/trace.test.ts
+++ b/packages/trace-directive/tests/trace.test.ts
@@ -71,7 +71,7 @@ describe("@trace directive", () => {
       schema,
       source: query,
       contextValue: {
-        // GraphQLDebuggerContext: new GraphQLDebuggerContext(),
+        // GraphQLDebuggerContext: new GraphQLDebuggerContext({ schema s }),
       },
     });
 
@@ -182,7 +182,7 @@ describe("@trace directive", () => {
       schema,
       source: query,
       contextValue: {
-        GraphQLDebuggerContext: new GraphQLDebuggerContext(),
+        GraphQLDebuggerContext: new GraphQLDebuggerContext({ schema }),
       },
     });
 
@@ -293,7 +293,7 @@ describe("@trace directive", () => {
       source: query,
       contextValue: {
         GraphQLDebuggerContext: new GraphQLDebuggerContext({
-          includeVariables: true,
+          schema,
         }),
       },
     });
@@ -359,7 +359,9 @@ describe("@trace directive", () => {
       schema,
       source: query,
       contextValue: {
-        GraphQLDebuggerContext: new GraphQLDebuggerContext(),
+        GraphQLDebuggerContext: new GraphQLDebuggerContext({
+          schema,
+        }),
       },
     });
 
@@ -438,7 +440,9 @@ describe("@trace directive", () => {
       contextValue: {
         name: randomName,
         [excludeContext]: excludeContext,
-        GraphQLDebuggerContext: new GraphQLDebuggerContext(),
+        GraphQLDebuggerContext: new GraphQLDebuggerContext({
+          schema,
+        }),
         req: {
           url: "http://localhost:3000/graphql",
         },
@@ -525,7 +529,7 @@ describe("@trace directive", () => {
       source: query,
       contextValue: {
         GraphQLDebuggerContext: new GraphQLDebuggerContext({
-          includeResult: true,
+          schema,
         }),
       },
     });
@@ -588,7 +592,7 @@ describe("@trace directive", () => {
       source: query,
       contextValue: {
         GraphQLDebuggerContext: new GraphQLDebuggerContext({
-          includeResult: true,
+          schema,
         }),
       },
     });
@@ -649,9 +653,7 @@ describe("@trace directive", () => {
       source: query,
       contextValue: {
         GraphQLDebuggerContext: new GraphQLDebuggerContext({
-          includeVariables: true,
-          includeResult: true,
-          includeContext: true,
+          schema,
         }),
       },
     });

--- a/plugins/apollo/src/index.ts
+++ b/plugins/apollo/src/index.ts
@@ -61,13 +61,14 @@ export const graphqlDebuggerPlugin = ({
 
       setupOtel({ exporterConfig, instrumentations });
     },
-    requestDidStart: async () => {
+    requestDidStart: async ({ schema }) => {
       const spanMap = new Map<string, ApiSpan>();
 
       return {
-        async executionDidStart(requestContext) {
-          const internalCtx = new GraphQLDebuggerContext();
-          internalCtx.setSchema(requestContext.schema);
+        async executionDidStart() {
+          const internalCtx = new GraphQLDebuggerContext({
+            schema,
+          });
 
           return {
             willResolveField(fieldCtx) {

--- a/plugins/yoga/src/create-yoga.ts
+++ b/plugins/yoga/src/create-yoga.ts
@@ -41,9 +41,9 @@ export function createYoga<
   if (!options.context) {
     const contextOverride = async (): Promise<TUserContext> => {
       return {
-        GraphQLDebuggerContext: new GraphQLDebuggerContext(
-          options?.debugger?.otelContextOptions,
-        ),
+        GraphQLDebuggerContext: new GraphQLDebuggerContext({
+          schema: options.schema,
+        }),
       } as unknown as TUserContext;
     };
 
@@ -55,9 +55,9 @@ export function createYoga<
     options.context = async function newContextFunction(...args) {
       const contextObject = await originalContextFunction(...args);
 
-      contextObject.GraphQLDebuggerContext = new GraphQLDebuggerContext(
-        options?.debugger?.otelContextOptions,
-      );
+      contextObject.GraphQLDebuggerContext = new GraphQLDebuggerContext({
+        schema: options.schema,
+      });
 
       return contextObject;
     };


### PR DESCRIPTION
For each request the schema needed to be sorted, hashed, and reprinted. I solved this by requiring `schema` input on `GraphQLDebuggerContext` construction. 