### PR TITLE
fix: precompute schemahash

### DIFF
--- a/benchmarks/apollo-debugger/index.js
+++ b/benchmarks/apollo-debugger/index.js
@@ -1,6 +1,5 @@
 import { graphqlDebuggerPlugin } from "@graphql-debugger/apollo-server";
 
-import { makeExecutableSchema } from "@graphql-tools/schema";
 import { ApolloServer } from "apollo-server";
 import cluster from "cluster";
 import { cpus } from "os";
@@ -12,7 +11,7 @@ if (cluster.isPrimary) {
     cluster.fork();
   }
 } else {
-  const schema = makeExecutableSchema({
+  const server = new ApolloServer({
     typeDefs: `
       type Query {
         hello: String!
@@ -23,10 +22,6 @@ if (cluster.isPrimary) {
         hello: () => "world",
       },
     },
-  });
-
-  const server = new ApolloServer({
-    schema,
     plugins: [graphqlDebuggerPlugin()],
   });
 

--- a/benchmarks/apollo-debugger/index.js
+++ b/benchmarks/apollo-debugger/index.js
@@ -1,5 +1,6 @@
 import { graphqlDebuggerPlugin } from "@graphql-debugger/apollo-server";
 
+import { makeExecutableSchema } from "@graphql-tools/schema";
 import { ApolloServer } from "apollo-server";
 import cluster from "cluster";
 import { cpus } from "os";
@@ -11,17 +12,21 @@ if (cluster.isPrimary) {
     cluster.fork();
   }
 } else {
-  const server = new ApolloServer({
+  const schema = makeExecutableSchema({
     typeDefs: `
-        type Query {
-          hello: String!
-        }
-      `,
+      type Query {
+        hello: String!
+      }
+    `,
     resolvers: {
       Query: {
         hello: () => "world",
       },
     },
+  });
+
+  const server = new ApolloServer({
+    schema,
     plugins: [graphqlDebuggerPlugin()],
   });
 

--- a/benchmarks/helix-debugger/index.js
+++ b/benchmarks/helix-debugger/index.js
@@ -57,10 +57,11 @@ if (cluster.isPrimary) {
       query,
       variables,
       request,
-      schema: tracedSchema,
+      schema: tracedSchema.schema,
       contextFactory: () => ({
         GraphQLDebuggerContext: new GraphQLDebuggerContext({
-          schema,
+          schema: tracedSchema.schema,
+          schemaHash: tracedSchema.schemaHash,
         }),
       }),
     });

--- a/docs/src/pages/docs/faq/missing-context.mdx
+++ b/docs/src/pages/docs/faq/missing-context.mdx
@@ -7,12 +7,15 @@ Inject the `GraphQLDebuggerContext` instance inside your GraphQL request context
 ```js
 import { GraphQLDebuggerContext } from "@graphql-debugger/trace-schema";
 
+const tracedScema = traceSchema({
+  schema,
+  adapter: // <-- See Adapters
+});
+
 const myServer = new GraphQLServerFooBar({
   schema,
   context: {
-    GraphQLDebuggerContext: new GraphQLDebuggerContext({
-      schema,
-    }),
+    GraphQLDebuggerContext: new GraphQLDebuggerContext(tracedSchema),
   },
 });
 ```

--- a/docs/src/pages/docs/how.mdx
+++ b/docs/src/pages/docs/how.mdx
@@ -210,8 +210,8 @@ const tracedSchema = traceSchema({
 
 // or
 const tracedSchema = traceSchema({
-schema,
-adapter,
+    schema,
+    adapter,
 });
 
 ```

--- a/e2e/tests/utils/create-test-schema.ts
+++ b/e2e/tests/utils/create-test-schema.ts
@@ -1,7 +1,6 @@
 import { DebuggerClient } from "@graphql-debugger/client";
 import { traceSchema } from "@graphql-debugger/trace-schema";
 import { Schema } from "@graphql-debugger/types";
-import { hashSchema } from "@graphql-debugger/utils";
 
 import { faker } from "@faker-js/faker";
 import { makeExecutableSchema } from "@graphql-tools/schema";
@@ -63,19 +62,17 @@ export async function createTestSchema({
     resolvers,
   });
 
-  const schema = traceSchema({
+  const { schema, schemaHash } = traceSchema({
     schema: executableSchema,
     adapter: client.adapter,
   });
 
-  const hash = hashSchema(schema);
-
   const dbSchema = await client.schema.upsert({
     where: {
-      hash,
+      hash: schemaHash,
     },
     input: {
-      hash: hash,
+      hash: schemaHash,
       typeDefs: typeDefs,
     },
   });
@@ -83,7 +80,7 @@ export async function createTestSchema({
   return {
     schema,
     typeDefs,
-    hash,
+    hash: schemaHash,
     dbSchema,
     query: /* GraphQL */ `
       query ${shouldNameQuery ? random : ""} {

--- a/packages/trace-directive/src/context.ts
+++ b/packages/trace-directive/src/context.ts
@@ -12,6 +12,7 @@ import { GraphQLSchema } from "graphql";
 
 export interface GraphQLDebuggerContextOptions {
   schema: GraphQLSchema;
+  schemaHash?: string;
 }
 
 export class GraphQLDebuggerContext {
@@ -23,7 +24,7 @@ export class GraphQLDebuggerContext {
 
   constructor(options: GraphQLDebuggerContextOptions) {
     this.schema = options.schema;
-    this.schemaHash = hashSchema(options.schema);
+    this.schemaHash = options.schemaHash || hashSchema(options.schema);
     this.tracer = getTracer();
   }
 

--- a/packages/trace-schema/src/trace-schema.ts
+++ b/packages/trace-schema/src/trace-schema.ts
@@ -2,6 +2,7 @@
 import { BaseAdapter } from "@graphql-debugger/adapter-base";
 import { SetupOtelInput, setupOtel } from "@graphql-debugger/opentelemetry";
 import { traceDirective } from "@graphql-debugger/trace-directive";
+import { hashSchema } from "@graphql-debugger/utils";
 
 import { makeExecutableSchema } from "@graphql-tools/schema";
 import { getResolversFromSchema } from "@graphql-tools/utils";
@@ -27,7 +28,7 @@ export function traceSchema({
   instrumentations,
   shouldExportSchema = true,
   shouldExcludeTypeFields = false,
-}: TraceSchemaInput): GraphQLSchema {
+}: TraceSchemaInput): { schema: GraphQLSchema; schemaHash: string } {
   debug("Tracing schema");
 
   setupOtel({ exporterConfig, instrumentations });
@@ -97,5 +98,8 @@ export function traceSchema({
 
   debug("Traced schema");
 
-  return tracedSchema;
+  return {
+    schema: tracedSchema,
+    schemaHash: hashSchema(tracedSchema),
+  };
 }

--- a/packages/trace-schema/tests/trace-schema.test.ts
+++ b/packages/trace-schema/tests/trace-schema.test.ts
@@ -35,7 +35,7 @@ describe("tracedSchema", () => {
       shouldExportSchema: false,
     });
 
-    const outputTypedefs = printSchemaWithDirectives(tracedSchema);
+    const outputTypedefs = printSchemaWithDirectives(tracedSchema.schema);
 
     expect(outputTypedefs).toMatchInlineSnapshot(`
 "schema {
@@ -99,7 +99,7 @@ type Query {
       shouldExcludeTypeFields: true,
     });
 
-    const outputTypedefs = printSchemaWithDirectives(tracedSchema);
+    const outputTypedefs = printSchemaWithDirectives(tracedSchema.schema);
 
     expect(outputTypedefs).toMatchInlineSnapshot(`
 "schema {


### PR DESCRIPTION
This PR exposes the schema hash when you use traceSchema so that you don't need to recompute it with each request. 

```ts
const tracedScema = traceSchema({
  schema,
  adapter: // <-- See Adapters
});

const myServer = new GraphQLServerFooBar({
  schema,
  context: {
    GraphQLDebuggerContext: new GraphQLDebuggerContext({ schema: tracedSchema.schema, schemaHash: tracedSchema.schemaHash }),
  },
});
```